### PR TITLE
chore: current_thread: switch to \persist

### DIFF
--- a/rocq-brick-libstdcpp/proof/mutex/spec/lock_guard.v
+++ b/rocq-brick-libstdcpp/proof/mutex/spec/lock_guard.v
@@ -81,7 +81,7 @@ Section with_cpp.
   cpp.spec "std::lock_guard<std::mutex>::~lock_guard()" as dtor_spec from source with (
     \this this
     \pre{mp g q P} this |-> R (mp, g, q) 1$m P
-    \pre{thr} current_thread thr
+    \persist{thr} current_thread thr
     \pre mutex.locked g thr q
     \pre ▷P
     \post

--- a/rocq-brick-libstdcpp/proof/mutex/spec/mutex.v
+++ b/rocq-brick-libstdcpp/proof/mutex/spec/mutex.v
@@ -78,7 +78,7 @@ Section with_cpp.
   cpp.spec "std::mutex::try_lock()" as try_lock_spec with
       (\this this
       \prepost{q P g} this |-> R g q P (* part of both pre and post *)
-      \prepost{th} current_thread th
+      \persist{th} current_thread th
       \pre token g q
       \post{b}[Vbool b] if b then P ** locked g th q else token g q).
 


### PR DESCRIPTION
This seems more consistent.