### PR TITLE
Close <iostream> refinement specifications

### DIFF
--- a/rocq-brick-libstdcpp/proof/iostream/spec.v
+++ b/rocq-brick-libstdcpp/proof/iostream/spec.v
@@ -46,8 +46,8 @@ Module ostream.
     Lemma bs_dos_fupd OS bs K : bs_dos OS bs K ⊣⊢ |={⊤}=> bs_dos OS bs K.
     Proof. destruct bs; simpl; rewrite fupd_idemp; done. Qed.
 
-    #[global] Instance elim_modal_fupd_wp_lval OS bs p P Q :
-      ElimModal True p false (|={top}=> P) P (bs_dos OS bs Q) (bs_dos OS bs Q).
+    #[global] Instance elim_modal_fupd_wp_lval E OS bs p P Q :
+      ElimModal True p false (|={E}=> P) P (bs_dos OS bs Q) (bs_dos OS bs Q).
     Proof.
       rewrite /ElimModal. rewrite bi.intuitionistically_if_elim/=.
       rewrite {2}bs_dos_fupd. iIntros (?) "[>h k] !>"; iApply "k"; done.

--- a/rocq-brick-libstdcpp/proof/iostream/spec.v
+++ b/rocq-brick-libstdcpp/proof/iostream/spec.v
@@ -35,12 +35,33 @@ Module ostream.
   Section with_cpp.
     Context `{Σ : cpp_logic, σ : genv}.
 
+    (** Run the handler on each character in the string *)
     Fixpoint bs_dos (OS : Ostream) (bs : bs) (K : mpred) : mpred :=
+      |={⊤}=>
       match bs with
       | BS.EmptyString => K
       | BS.String b bs => OS.(do) {[Write $ Byte.to_N b]} $ fun _ => bs_dos OS bs K
       end.
     #[global] Hint Opaque bs_dos : sl_opacity.
+    Lemma bs_dos_fupd OS bs K : bs_dos OS bs K ⊣⊢ |={⊤}=> bs_dos OS bs K.
+    Proof. destruct bs; simpl; rewrite fupd_idemp; done. Qed.
+
+    #[global] Instance elim_modal_fupd_wp_lval OS bs p P Q :
+      ElimModal True p false (|={top}=> P) P (bs_dos OS bs Q) (bs_dos OS bs Q).
+    Proof.
+      rewrite /ElimModal. rewrite bi.intuitionistically_if_elim/=.
+      rewrite {2}bs_dos_fupd. iIntros (?) "[>h k] !>"; iApply "k"; done.
+    Qed.
+    #[global] Instance elim_modal_bupd_wp_lval OS bs p P Q :
+      ElimModal True p false (|==> P) P (bs_dos OS bs Q) (bs_dos OS bs Q).
+    Proof.
+      rewrite /ElimModal (bupd_fupd top). exact: elim_modal_fupd_wp_lval.
+    Qed.
+    #[global] Instance add_modal_fupd_wp_lval OS bs P Q : AddModal (|={top}=> P) P (bs_dos OS bs Q).
+    Proof.
+      rewrite/AddModal.
+      rewrite {2}bs_dos_fupd. iIntros "[>h k] !>"; iApply "k"; done.
+    Qed.
 
     #[global]
     Instance bs_dos_proper_frame (OS: Ostream) b
@@ -48,8 +69,9 @@ Module ostream.
     Proof.
       constructor; intros.
       induction b; simpl.
-      { iIntros "X"; iApply ("X" $! ()). }
+      { iIntros "X >K !>"; iRevert "K"; iApply ("X" $! ()). }
       { iIntros "X". destruct OS.
+        iIntros ">Y !>"; iRevert "Y".
         iApply (do_frame {[Write $ Byte.to_N b]}).(kont._frame).
         iIntros ([?[]]); simpl.
         iApply IHb. iAssumption. }
@@ -59,7 +81,6 @@ Module ostream.
     Instance bs_dos_positive_proper_frame_eta (OS: Ostream) b
       : kont.ProperFrame (T:=[tele]) (fun x => bs_dos OS b x).
     Proof. apply bs_dos_proper_frame. Qed.
-
 
     cpp.spec "std::operator<<<std::char_traits<char>>(std::basic_ostream<char, std::char_traits<char>>&, const char*)"
       from source as ostream_insert_spec with (

--- a/rocq-brick-libstdcpp/proof/iostream/spec.v
+++ b/rocq-brick-libstdcpp/proof/iostream/spec.v
@@ -44,7 +44,7 @@ Module ostream.
       end.
     #[global] Hint Opaque bs_dos : sl_opacity.
     Lemma bs_dos_fupd OS bs K : bs_dos OS bs K ⊣⊢ |={⊤}=> bs_dos OS bs K.
-    Proof. destruct bs; simpl; rewrite fupd_idemp; done. Qed.
+    Proof. by destruct bs => /=; rewrite fupd_idemp. Qed.
 
     #[global] Instance elim_modal_fupd_wp_lval E OS bs p P Q :
       ElimModal True p false (|={E}=> P) P (bs_dos OS bs Q) (bs_dos OS bs Q).

--- a/rocq-brick-libstdcpp/test/g4g/N12_area.v
+++ b/rocq-brick-libstdcpp/test/g4g/N12_area.v
@@ -24,37 +24,20 @@ Section with_cpp.
   Context `{SPECTRA : !appG APP _Σ}.
 
   #[local] Instance Area : App.app := mkApp APP.
-  (* NOTE: Specializing this hint is necessary due to
-     the current Spectra packaging *)
-  Definition X := Step.requester Area.
-  #[local] Hint Resolve X : sl_opacity.
-
-  (* NOTE: generalizing this over an [App.app] is difficult because [App.app] hides
-     the event signature. *)
   #[program]
-  Definition OS (E : coPset) γ : Ostream :=
-    {| do := Step.requester Area E γ |}%I.
-  Next Obligation. intros. repeat intro. by apply requester_ne. Qed.
+  Definition OS γ : Ostream :=
+    AppHandler Area (⊤ ∖ ↑refinement_rootNS) masks.default γ.
 
-  #[program]
-  Definition bs_dos_steps_C (s : bs) (s' : propset (Sts._state (App.lts Area))) str
-    (ANY_STEPS : AnySteps only_output {[s]} ((fun x => Write x) <$> BS.string_to_bytes str) s') :=
-    \cancelx
-    \using{γ} AuthSet.frag γ {[s]}
-    \proving{K : mpredI} ostream.bs_dos (OS ⊤ γ) str K
-    \through (AuthSet.frag γ s' -∗ K)
-    \end@{mpredI}.
-  Next Obligation.
-    simpl.
-    intros.
-    iIntros "F" (?) "K".
-    rewrite /Step.requester.
-  Admitted.
+  (* NOTE: the following two specializations work around issues with the
+     Spectra packaging which uses bundling. *)
+  Definition gen_X := gen_requester_C Area.
+  Hint Resolve gen_X : sl_opacity.
+  Definition bs_dos_steps_C := gen_bs_dos_steps_C Area.(App.lts) Area.(App.inG).
   Hint Resolve bs_dos_steps_C : sl_opacity.
 
-
   cpp.spec "main()" from source as main_spec with (
-    \prepost{γ osM} _global "std::cout" |-> ostream.R (OS ⊤ γ) osM 1$m
+    \prepost{γ osM} _global "std::cout" |-> ostream.R (OS γ) osM 1$m
+    \persist Step.updater Area (⊤ ∖ ↑refinement_rootNS) γ
     \pre AuthSet.frag γ {[ behavior side1 side2 ]}
     \post[Vint 0]  AuthSet.frag γ {[ ""%bs ]}).
 

--- a/rocq-brick-libstdcpp/test/g4g/N1_hello_world.v
+++ b/rocq-brick-libstdcpp/test/g4g/N1_hello_world.v
@@ -34,11 +34,6 @@ Section with_cpp.
     \pre AuthSet.frag γ {[ "Hello World"%bs ]}
     \post[Vint 0]  AuthSet.frag γ {[ ""%bs ]}).
 
-  (* Hint Resolve default_masks_valid : pure. *)
-  Hint Extern 0 (masks.valid _ _) => (red; set_solver) : pure.
-
-  Opaque ostream.bs_dos.
-
   Lemma main_ok : verify[source] "main()".
   Proof.
     #[local] Opaque ostream.bs_dos.

--- a/rocq-brick-libstdcpp/test/g4g/N1_hello_world.v
+++ b/rocq-brick-libstdcpp/test/g4g/N1_hello_world.v
@@ -15,23 +15,36 @@ Section with_cpp.
   Context `{SPECTRA : !appG APP _Σ}.
 
   #[local] Instance HelloWorld : App.app := mkApp APP.
-  Definition X := requester_C HelloWorld.
-  Hint Resolve X : sl_opacity.
 
-  (* NOTE: generalizing this over an [App.app] is difficult because [App.app] hides
-     the event signature. *)
-  #[program]
-  Definition OS (E : coPset) γ : Ostream :=
-  {| do := Step.requester HelloWorld E γ |}%I.
-  Next Obligation. intros. repeat intro. by apply requester_ne. Qed.
+  Definition OS γ : Ostream :=
+    AppHandler HelloWorld (⊤ ∖ ↑refinement_rootNS) masks.default γ.
+
+  (* NOTE: the following two specializations work around issues with the
+     Spectra packaging which uses bundling. *)
+  Definition gen_X := gen_requester_C HelloWorld.
+  Hint Resolve gen_X : sl_opacity.
+  Definition bs_dos_steps_C :=
+    gen_bs_dos_steps_C HelloWorld.(App.lts) HelloWorld.(App.inG).
+  Hint Resolve bs_dos_steps_C : sl_opacity.
+
 
   cpp.spec "main()" from source as main_spec with (
-    \prepost{γ osM} _global "std::cout" |-> ostream.R (OS ⊤ γ) osM 1$m
+    \prepost{γ osM} _global "std::cout" |-> ostream.R (OS γ) osM 1$m
+    \persist Step.updater HelloWorld (⊤ ∖ ↑refinement_rootNS) γ
     \pre AuthSet.frag γ {[ "Hello World"%bs ]}
     \post[Vint 0]  AuthSet.frag γ {[ ""%bs ]}).
 
+  (* Hint Resolve default_masks_valid : pure. *)
+  Hint Extern 0 (masks.valid _ _) => (red; set_solver) : pure.
+
+  Opaque ostream.bs_dos.
 
   Lemma main_ok : verify[source] "main()".
-  Proof. verify_shift; go. banish_string_literals. iModIntro; go. Qed.
+  Proof.
+    #[local] Opaque ostream.bs_dos.
+    verify_shift; go.
+    banish_string_literals.
+    iModIntro; go.
+  Qed.
 
 End with_cpp.

--- a/rocq-brick-libstdcpp/test/g4g/N4_sum.v
+++ b/rocq-brick-libstdcpp/test/g4g/N4_sum.v
@@ -24,7 +24,7 @@ Section with_cpp.
 
   cpp.spec "main()" from source as main_spec with (
     \prepost{γ osM} _global "std::cout" |-> ostream.R (OS γ) osM 1$m
-    \prepost Step.updater Sum (⊤ ∖ ↑refinement_rootNS) γ
+    \persist Step.updater Sum (⊤ ∖ ↑refinement_rootNS) γ
     \pre AuthSet.frag γ {[ ostream.format_int 20 ]}
     \post[Vint 0]  AuthSet.frag γ {[ ""%bs ]}).
 

--- a/rocq-brick-libstdcpp/test/g4g/N4_sum.v
+++ b/rocq-brick-libstdcpp/test/g4g/N4_sum.v
@@ -11,42 +11,20 @@ Section with_cpp.
   Context `{SPECTRA : !appG APP _Σ}.
 
   #[local] Instance Sum : App.app := mkApp APP.
-  (* NOTE: Specializing this hint is necessary due to
-     the current Spectra packaging *)
-  Definition X := Step.requester Sum.
-  #[local] Hint Resolve X : sl_opacity.
-
-
   #[program]
-  Definition OS (E : coPset) γ : Ostream :=
-    {| do := Step.requester Sum E γ |}%I.
-  Next Obligation. repeat intro. apply requester_ne; done. Qed.
+  Definition OS γ : Ostream :=
+    AppHandler Sum (⊤ ∖ ↑refinement_rootNS) masks.default γ.
 
-  #[program]
-  Definition bs_dos_steps_C str (s s' : propset (Sts._state (App.lts Sum)))
-    (ANY_STEPS : AnySteps only_output s ((fun x => Write x) <$> BS.string_to_bytes str) s') :=
-    \cancelx
-    \using{γ} AuthSet.frag γ s
-    \proving{K : mpredI} ostream.bs_dos (OS ⊤ γ) str K
-    \through (AuthSet.frag γ s' -∗ K)
-    \end@{mpredI}.
-  Next Obligation.
-    simpl. clear.
-    intros str s s' ANY_STEP.
-    remember ((fun x => Write x) <$> BS.string_to_bytes str) as X.
-    generalize dependent str.
-    induction ANY_STEP; simpl.
-    { destruct str; simpl; try congruence.
-      intros. admit. }
-    { destruct str; simpl; try congruence.
-      inversion 1; subst; intros. admit.
-    }
-    { admit. }
-  Admitted.
+  (* NOTE: the following two specializations work around issues with the
+     Spectra packaging which uses bundling. *)
+  Definition gen_X := gen_requester_C Sum.
+  Hint Resolve gen_X : sl_opacity.
+  Definition bs_dos_steps_C := gen_bs_dos_steps_C Sum.(App.lts) Sum.(App.inG).
   Hint Resolve bs_dos_steps_C : sl_opacity.
 
   cpp.spec "main()" from source as main_spec with (
-    \prepost{γ osM} _global "std::cout" |-> ostream.R (OS ⊤ γ) osM 1$m
+    \prepost{γ osM} _global "std::cout" |-> ostream.R (OS γ) osM 1$m
+    \prepost Step.updater Sum (⊤ ∖ ↑refinement_rootNS) γ
     \pre AuthSet.frag γ {[ ostream.format_int 20 ]}
     \post[Vint 0]  AuthSet.frag γ {[ ""%bs ]}).
 

--- a/rocq-brick-libstdcpp/test/g4g/N4_sum_a.v
+++ b/rocq-brick-libstdcpp/test/g4g/N4_sum_a.v
@@ -6,57 +6,32 @@ Import linearity.
 
 #[local] Open Scope Z_scope.
 
-Definition output_app (init : bs -> Prop) : LTS output_event :=
-  {| Sts._state := bs
-   ; Sts._init_state := init
-   ; Sts._step := only_output |}.
-
-
 Section with_cpp.
   Context `{Σ : cpp_logic, σ : genv}.
+
+  #[local] Notation APP := (output_app (eq $ ostream.format_int 20)).
+
   Context `{SPECTRA : !appG (output_app (eq $ ostream.format_int 20)) _Σ}.
 
+  #[local] Instance Sum : App.app := mkApp APP.
   #[program]
-  Instance Sum : App.app :=
-    {| App.evt := output_event
-    ; App.lts := output_app (eq $ ostream.format_int 20)
-    ; App.inG := _
-    |}.
-  Next Obligation.
-    unshelve eapply mpred_prop.mpred_has_usual_own. apply SPECTRA.
-  Defined.
+    Definition OS γ : Ostream :=
+    AppHandler Sum (⊤ ∖ ↑refinement_rootNS) masks.default γ.
 
-  #[program]
-  Definition OS (E : coPset) γ : Ostream :=
-    {| do := Step.requester Sum E γ |}%I.
-  Next Obligation. repeat intro. apply requester_ne; done. Qed.
-
-  Definition X := Step.requester Sum.
-  #[local] Hint Resolve X : sl_opacity.
-
-  #[program]
-  Definition bs_dos_steps_C (s : bs) (s' : propset (Sts._state (App.lts Sum))) str
-    (ANY_STEPS : AnySteps only_output {[s]} ((fun x => Write x) <$> BS.string_to_bytes str) s') :=
-    \cancelx
-    \using{γ} AuthSet.frag γ {[s]}
-    \proving{K : mpredI} ostream.bs_dos (OS ⊤ γ) str K
-    \through (AuthSet.frag γ s' -∗ K)
-    \end@{mpredI}.
-  Next Obligation.
-    simpl.
-    intros.
-    iIntros "F" (?) "K".
-    rewrite /Step.requester.
-  Admitted.
+  (* NOTE: the following two specializations work around issues with the
+     Spectra packaging which uses bundling. *)
+  Definition gen_X := gen_requester_C Sum.
+  Hint Resolve gen_X : sl_opacity.
+  Definition bs_dos_steps_C := gen_bs_dos_steps_C Sum.(App.lts) Sum.(App.inG).
   Hint Resolve bs_dos_steps_C : sl_opacity.
 
   cpp.spec "main()" from source as main_spec with (
-    \prepost{γ osM} _global "std::cout" |-> ostream.R (OS ⊤ γ) osM 1$m
+    \prepost{γ osM} _global "std::cout" |-> ostream.R (OS γ) osM 1$m
+    \persist Step.updater Sum (⊤ ∖ ↑refinement_rootNS) γ
     \pre AuthSet.frag γ {[ ostream.format_int 20 ]}
     \post[Vint 0]  AuthSet.frag γ {[ ""%bs ]}).
 
-
-  Lemma main_ok : verify[source] main_spec.
+  Lemma main_ok : verify[source] "main()".
   Proof.
     verify_spec; go.
 

--- a/rocq-brick-libstdcpp/test/g4g/N4_sum_a.v
+++ b/rocq-brick-libstdcpp/test/g4g/N4_sum_a.v
@@ -15,7 +15,7 @@ Section with_cpp.
 
   #[local] Instance Sum : App.app := mkApp APP.
   #[program]
-    Definition OS γ : Ostream :=
+  Definition OS γ : Ostream :=
     AppHandler Sum (⊤ ∖ ↑refinement_rootNS) masks.default γ.
 
   (* NOTE: the following two specializations work around issues with the

--- a/rocq-brick-libstdcpp/test/g4g/N5_swap.v
+++ b/rocq-brick-libstdcpp/test/g4g/N5_swap.v
@@ -18,32 +18,20 @@ Section with_cpp.
   Context `{SPECTRA : !appG APP _Σ}.
 
   #[local] Instance Swap : App.app := mkApp APP.
-  Definition X := requester_C Swap.
-  Hint Resolve X : sl_opacity.
-
   #[program]
-  Definition OS (E : coPset) γ : Ostream :=
-    {| do := Step.requester Swap E γ |}%I.
-  Next Obligation. repeat intro. apply requester_ne; done. Qed.
+  Definition OS γ : Ostream :=
+    AppHandler Swap (⊤ ∖ ↑refinement_rootNS) masks.default γ.
 
-  #[program]
-  Definition bs_dos_steps_C (s : bs) (s' : propset (Sts._state (App.lts Swap))) str
-    (ANY_STEPS : AnySteps only_output {[s]} ((fun x => Write x) <$> BS.string_to_bytes str) s') :=
-    \cancelx
-    \using{γ} AuthSet.frag γ {[s]}
-    \proving{K : mpredI} ostream.bs_dos (OS ⊤ γ) str K
-    \through (AuthSet.frag γ s' -∗ K)
-    \end@{mpredI}.
-  Next Obligation.
-    simpl.
-    intros.
-    iIntros "F" (?) "K".
-    rewrite /Step.requester.
-  Admitted.
+  (* NOTE: the following two specializations work around issues with the
+     Spectra packaging which uses bundling. *)
+  Definition gen_X := gen_requester_C Swap.
+  Hint Resolve gen_X : sl_opacity.
+  Definition bs_dos_steps_C := gen_bs_dos_steps_C Swap.(App.lts) Swap.(App.inG).
   Hint Resolve bs_dos_steps_C : sl_opacity.
 
   cpp.spec "main()" from source as main_spec with (
-    \prepost{γ osM} _global "std::cout" |-> ostream.R (OS ⊤ γ) osM 1$m
+    \prepost{γ osM} _global "std::cout" |-> ostream.R (OS γ) osM 1$m
+    \persist Step.updater Swap (⊤ ∖ ↑refinement_rootNS) γ
     \pre AuthSet.frag γ {[ behavior 2 3 ]}
     \post[Vint 0]  AuthSet.frag γ {[ ""%bs ]}).
 

--- a/rocq-brick-libstdcpp/test/g4g/N5_swap_a.v
+++ b/rocq-brick-libstdcpp/test/g4g/N5_swap_a.v
@@ -12,36 +12,22 @@ Section with_cpp.
   Context `{SPECTRA : !appG APP _Σ}.
 
   #[local] Instance Swap : App.app := mkApp APP.
-  Definition X := requester_C Swap.
-  Hint Resolve X : sl_opacity.
-
   #[program]
-  Definition OS (E : coPset) γ : Ostream :=
-    {| do := Step.requester Swap E γ |}%I.
-  Next Obligation. repeat intro. apply requester_ne; done. Qed.
+    Definition OS γ : Ostream :=
+    AppHandler Swap (⊤ ∖ ↑refinement_rootNS) masks.default γ.
 
-
-  cpp.spec "main()" from source as main_spec with (
-    \prepost{γ osM} _global "std::cout" |-> ostream.R (OS ⊤ γ) osM 1$m
-    \pre AuthSet.frag γ {[ behavior 2 3 ]}
-    \post[Vint 0]  AuthSet.frag γ {[ ""%bs ]}).
-
-  #[program]
-  Definition bs_dos_steps_C (s : bs) (s' : propset (Sts._state (App.lts Swap))) str
-    (ANY_STEPS : AnySteps only_output {[s]} ((fun x => Write x) <$> BS.string_to_bytes str) s') :=
-    \cancelx
-      \using{γ} AuthSet.frag γ {[s]}
-      \proving{K : mpredI} ostream.bs_dos (OS ⊤ γ) str K
-      \through (AuthSet.frag γ s' -∗ K)
-      \end@{mpredI}.
-  Next Obligation.
-    simpl.
-    intros.
-    iIntros "F" (?) "K".
-    rewrite /Step.requester.
-  Admitted.
+  (* NOTE: the following two specializations work around issues with the
+     Spectra packaging which uses bundling. *)
+  Definition gen_X := gen_requester_C Swap.
+  Hint Resolve gen_X : sl_opacity.
+  Definition bs_dos_steps_C := gen_bs_dos_steps_C Swap.(App.lts) Swap.(App.inG).
   Hint Resolve bs_dos_steps_C : sl_opacity.
 
+  cpp.spec "main()" from source as main_spec with (
+    \prepost{γ osM} _global "std::cout" |-> ostream.R (OS γ) osM 1$m
+    \persist Step.updater Swap (⊤ ∖ ↑refinement_rootNS) γ
+    \pre AuthSet.frag γ {[ behavior 2 3 ]}
+    \post[Vint 0]  AuthSet.frag γ {[ ""%bs ]}).
 
   Lemma main_ok : verify[source] "main()".
   Proof.

--- a/rocq-brick-libstdcpp/test/g4g/N5_swap_a.v
+++ b/rocq-brick-libstdcpp/test/g4g/N5_swap_a.v
@@ -13,7 +13,7 @@ Section with_cpp.
 
   #[local] Instance Swap : App.app := mkApp APP.
   #[program]
-    Definition OS γ : Ostream :=
+  Definition OS γ : Ostream :=
     AppHandler Swap (⊤ ∖ ↑refinement_rootNS) masks.default γ.
 
   (* NOTE: the following two specializations work around issues with the
@@ -39,4 +39,3 @@ Section with_cpp.
     work.
   Qed.
 End with_cpp.
-

--- a/rocq-brick-libstdcpp/test/g4g/N6_print_sizeof.v
+++ b/rocq-brick-libstdcpp/test/g4g/N6_print_sizeof.v
@@ -20,32 +20,21 @@ Section with_cpp.
   Context `{SPECTRA : !appG APP _Σ}.
 
   #[local] Instance SizeOf : App.app := mkApp APP.
-  Definition X := requester_C SizeOf.
-  Hint Resolve X : sl_opacity.
-
   #[program]
-  Definition OS (E : coPset) γ : Ostream :=
-    {| do evt K := Step.requester SizeOf E γ evt K |}%I.
-  Next Obligation. repeat intro. apply requester_ne; done. Qed.
+  Definition OS γ : Ostream :=
+    AppHandler SizeOf (⊤ ∖ ↑refinement_rootNS) masks.default γ.
 
-  #[program]
-  Definition bs_dos_steps_C (s : bs) (s' : propset (Sts._state (App.lts SizeOf))) str
-    (ANY_STEPS : AnySteps only_output {[s]} ((fun x => Write x) <$> BS.string_to_bytes str) s') :=
-    \cancelx
-    \using{γ} AuthSet.frag γ {[s]}
-    \proving{K : mpredI} ostream.bs_dos (OS ⊤ γ) str K
-    \through (AuthSet.frag γ s' -∗ K)
-    \end@{mpredI}.
-  Next Obligation.
-    simpl.
-    intros.
-    iIntros "F" (?) "K".
-    rewrite /Step.requester.
-  Admitted.
+  (* NOTE: the following two specializations work around issues with the
+     Spectra packaging which uses bundling. *)
+  Definition gen_X := gen_requester_C SizeOf.
+  Hint Resolve gen_X : sl_opacity.
+  Definition bs_dos_steps_C :=
+    gen_bs_dos_steps_C SizeOf.(App.lts) SizeOf.(App.inG).
   Hint Resolve bs_dos_steps_C : sl_opacity.
 
   cpp.spec "main()" from source as main_spec with (
-    \prepost{γ osM} _global "std::cout" |-> ostream.R (OS ⊤ γ) osM 1$m
+    \prepost{γ osM} _global "std::cout" |-> ostream.R (OS γ) osM 1$m
+    \prepost Step.updater SizeOf (⊤ ∖ ↑refinement_rootNS) γ
     \pre AuthSet.frag γ {[ behavior ]}
     \post[Vint 0]  AuthSet.frag γ {[ ""%bs ]}).
 

--- a/rocq-brick-libstdcpp/test/g4g/N6_print_sizeof.v
+++ b/rocq-brick-libstdcpp/test/g4g/N6_print_sizeof.v
@@ -34,7 +34,7 @@ Section with_cpp.
 
   cpp.spec "main()" from source as main_spec with (
     \prepost{γ osM} _global "std::cout" |-> ostream.R (OS γ) osM 1$m
-    \prepost Step.updater SizeOf (⊤ ∖ ↑refinement_rootNS) γ
+    \persist Step.updater SizeOf (⊤ ∖ ↑refinement_rootNS) γ
     \pre AuthSet.frag γ {[ behavior ]}
     \post[Vint 0]  AuthSet.frag γ {[ ""%bs ]}).
 

--- a/rocq-brick-libstdcpp/test/g4g/prelude.v
+++ b/rocq-brick-libstdcpp/test/g4g/prelude.v
@@ -84,13 +84,11 @@ Section operational.
       (_ : AnyStep Pre (Some evt) Mid)
       (_ : AnySteps Mid evts Post)
     : AnySteps Pre (evt :: evts) Post
-(*
   | Tau {evts Mid Post}
       (* Tau events are not stored in the trace *)
       (_ : AnyStep Pre None Mid)
       (_ : AnySteps Mid evts Post)
     : AnySteps Pre evts Post
-*)
   | Refine {Pre'} (_ : Pre' ⊆ Pre) {_ : exists s, s ∈ Pre'}  {es Post} :
     AnySteps Pre' es Post -> AnySteps Pre es Post.
 
@@ -122,7 +120,7 @@ Section operational.
   Proof.
     induction 1; intuition.
     - by destruct H.
-(*    - by destruct H. *)
+    - by destruct H.
     - destruct H0 as [x ?]; exists x. eapply elem_of_subseteq; eauto.
   Qed.
 End operational.
@@ -220,6 +218,37 @@ Section to_spectra.
 
   Lemma default_masks_valid : masks.valid masks.default (⊤ ∖ ↑refinement_rootNS).
   Proof. red. set_solver. Qed.
+
+  Lemma use_updater APP E γ sset (_ : exists s, s ∈ sset) (_ : Step.tau_safe APP.(App.lts) sset) :
+    Step.updater APP E γ
+    ⊢ AuthSet.frag γ sset -∗
+      |={E}=> AuthSet.frag γ {[ s' | (∃ s : lts_state (App.lts APP), s ∈ sset ∧ lts_step (App.lts APP) s None s')%type ]}.
+  Proof.
+    rewrite Step.updater_unseal/Step.updater_def.
+    iIntros "#u".
+    iApply "u"; iPureIntro; eauto.
+  Qed.
+
+  Lemma subseteq_PropSet {A} P xs : xs ⊆ PropSet P <-> forall x : A, x ∈ xs -> P x.
+  Proof.
+    split; intros.
+    - rewrite -elem_of_PropSet; apply H; done.
+    - do 2 intro. rewrite elem_of_PropSet; apply H; done.
+  Qed.
+
+  Lemma updater_anystep {_ : BiBUpdFUpd PROP} (app : App.app) ss ss' E
+    (ANY_STEP : AnyStep app.(App.lts).(Sts._step) ss None ss') γ :
+    AuthSet.frag γ ss
+    ⊢ Step.updater app E γ -∗ |={E}=> AuthSet.frag γ ss'.
+  Proof.
+    iIntros "f #u".
+    iDestruct (use_updater with "u f") as ">X".
+    { apply ANY_STEP. }
+    { intros. apply ANY_STEP in H0. destruct H0. eexists; intuition eauto. }
+    iDestruct (AuthSet.frag_upd with "X") as ">$"; eauto.
+    rewrite subseteq_PropSet.
+    by apply ANY_STEP.
+  Qed.
 
   Lemma requester_anystep {_ : BiBUpdFUpd PROP} (app : App.app) (s : _) s' e
     (ANY_STEP : AnyStep app.(App.lts).(Sts._step) {[s]} (Some e) s') γ :
@@ -377,29 +406,37 @@ Section app_handler_hints.
     (ANY_STEPS : AnySteps APP.(App.lts).(Sts._step) s ((fun x => Write x) <$> BS.string_to_bytes str) s') :=
     \cancelx
     \using{γ} AuthSet.frag γ s
+    \using Step.updater APP (⊤ ∖ ↑refinement_rootNS) γ
     \proving{K : mpredI} ostream.bs_dos (AppHandler APP (⊤ ∖ ↑refinement_rootNS) masks.default γ) str K
     \through (AuthSet.frag γ s' -∗ K)
     \end@{mpredI}.
   Next Obligation.
-    simpl. clear.
-    intros ? ? str s s' ANY_STEPS.
+    clear.
+    intros ? ? APP str s s' ANY_STEPS.
     remember ((fun x => Write x) <$> BS.string_to_bytes str) as X.
     generalize dependent str.
     induction ANY_STEPS; simpl.
     { destruct str; simpl; try congruence.
-      intros. iIntros "f" (?) "k". iApply "k"; done. }
+      intros. iIntros "[f #_]" (?) "k". iApply "k"; done. }
     { destruct str; simpl; try congruence.
       inversion 1; subst; intros.
-      iIntros "f" (?) "k".
-      eapply (gen_requester_anystep {| App.evt := output_event; App.lts := lts0; App.inG := inG |}) in H.
+      iIntros "[f #u]" (?) "k".
+      eapply (gen_requester_anystep APP) in H.
       iDestruct (H with "f") as "X"; clear H.
       iApply "X".
       { iPureIntro. exact default_masks_valid. }
-      { iIntros "!> f". iApply (IHANY_STEPS with "f k"). } }
+      { iIntros "!> f". iApply (IHANY_STEPS with "[f u] k"). iFrame "#∗". } }
+    { (* tau *)
+      intros; subst.
+      iIntros "[f #u]" (?) "k".
+      rewrite ostream.bs_dos_fupd. (* TODO: shouldn't be necessary, I must have the wrong instances *)
+      iDestruct ((updater_anystep APP _ _ _ H) with "f u") as ">f". iModIntro.
+      iApply (IHANY_STEPS with "[f u] k").
+      iFrame "#∗". }
     { intros; subst.
-      iIntros "f" (?) "k".
-      iDestruct (AuthSet.frag_upd with "f") as ">X"; first done.
-      by iApply (IHANY_STEPS with "X"). }
+      iIntros "[f #u]" (?) "k".
+      iDestruct (AuthSet.frag_upd with "f") as ">f"; first done.
+      iApply (IHANY_STEPS with "[f u]"); iFrame "#∗". }
   Qed.
 
 End app_handler_hints.

--- a/rocq-brick-libstdcpp/test/g4g/prelude.v
+++ b/rocq-brick-libstdcpp/test/g4g/prelude.v
@@ -9,7 +9,7 @@ Require Export skylabs.iris.extra.base_logic.lib.spectra.
 Class appG {evt : Type} (lts : LTS evt) (Σ : gFunctors) : Type :=
 { _has_auth_set_state : inG Σ (auth_setR (lts_state lts)) }.
 
-Section to_spectra.
+Section to_spectra_mpred.
   Context `{Σ : cpp_logic}.
 
   #[program]
@@ -21,7 +21,7 @@ Section to_spectra.
   Next Obligation.
     intros. unshelve eapply mpred_prop.mpred_has_usual_own. apply SPECTRA.
   Defined.
-End to_spectra.
+End to_spectra_mpred.
 
 Section to_auto.
   Context {PROP : bi}.
@@ -135,8 +135,8 @@ Section to_spectra.
   Context `{SPECTRA : @appG evt lts Σ}.
 
 
-  #[global] Instance requester_frame' T app E γ ps (F : (T -t> PROP) -> [tele (_:App.evt app)] -t> PROP)
- :
+  #[global]
+  Instance requester_frame' T app E γ ps (F : (T -t> PROP) -> [tele (_:App.evt app)] -t> PROP) :
     (forall x, kont.ProperFrame (PROP:=PROP) (T:=T) (fun K => F K x)) ->
     kont.ProperFrame (PROP:=PROP) (T:=T) (fun K => Step.requester app E γ ps (F K)).
   Proof.
@@ -149,6 +149,46 @@ Section to_spectra.
     iIntros (? e); destruct (H e).
     iApply _frame. done.
   Qed.
+
+  #[global]
+  Instance gen_requester_frame' T app E m γ ps (F : (T -t> PROP) -> [tele (_:App.evt app)] -t> PROP) :
+    (forall x, kont.ProperFrame (PROP:=PROP) (T:=T) (fun K => F K x)) ->
+    kont.ProperFrame (PROP:=PROP) (T:=T) (fun K => Step.gen_requester app E m γ ps (F K)).
+  Proof.
+    intros.
+    constructor.
+    iIntros (??) "K H".
+    rewrite /Step.requester.
+    iApply (atomic_commit_ppost_wand with "[H]") => //.
+    simpl.
+    iIntros (? e); destruct (H e).
+    iApply _frame. done.
+  Qed.
+
+  #[global]
+  Instance requester_ne {app E γ} :
+    forall n, Proper ((≡) ==> pointwise_relation _ (dist n) ==> dist n) (Step.requester app E γ).
+  Proof.
+    repeat intro.
+    apply atomic_commit_ne => //; repeat intro;
+                              repeat match goal with
+                                | h : tele_arg _ |- _ => destruct h
+                                end; simpl; repeat f_equiv; eauto.
+    by setoid_rewrite H.
+  Qed.
+
+  #[global]
+  Instance gen_requester_ne {app E m γ} :
+    forall n, Proper ((≡) ==> pointwise_relation _ (dist n) ==> dist n) (Step.gen_requester app E m γ).
+  Proof.
+    repeat intro.
+    apply atomic_commit_ne => //; repeat intro;
+                              repeat match goal with
+                                | h : tele_arg _ |- _ => destruct h
+                                end; simpl; repeat f_equiv; eauto.
+    by setoid_rewrite H.
+  Qed.
+
 
   Context {T : Type} {HAS_OWN : prop_constraints.HasUsualOwn PROP (auth_setR T)}.
   Lemma frag_frag_exact  γ val :
@@ -212,17 +252,6 @@ Section to_spectra.
   Qed.
   Hint Resolve requester_C : sl_opacity.
 
-  #[global]
-  Instance requester_ne {app E γ} :
-    forall n, Proper ((≡) ==> pointwise_relation _ (dist n) ==> dist n) (Step.requester app E γ).
-  Proof.
-    repeat intro.
-    apply atomic_commit_ne => //; repeat intro;
-                             repeat match goal with
-                               | h : tele_arg _ |- _ => destruct h
-                               end; simpl; repeat f_equiv; eauto.
-    by setoid_rewrite H.
-  Qed.
 
   (* NOTE: generalizing this over an [App.app] is difficult because [App.app] hides
      the event signature. *)

--- a/rocq-brick-libstdcpp/test/g4g/prelude.v
+++ b/rocq-brick-libstdcpp/test/g4g/prelude.v
@@ -252,13 +252,6 @@ Section to_spectra.
   Qed.
   Hint Resolve requester_C : sl_opacity.
 
-
-  (* NOTE: generalizing this over an [App.app] is difficult because [App.app] hides
-     the event signature. *)
-  #[program]
-  Definition OS (APP: App.app) (E : coPset) γ : SepHandler PROP (App.evt APP) :=
-    {| do evt K := Step.requester APP E γ evt K |}%I.
-
 End to_spectra.
 #[global] Hint Resolve frag_frag_exact_B frag_frag_exact_F : sl_opacity.
 
@@ -312,6 +305,10 @@ Section to_kont.
   Qed.
 End to_kont.
 (* END UPSTREAM *)
+
+Definition AppHandler {PROP : bi} {HasFupd : BiFUpd PROP} {HasGhost : prop_constraints.Ghostly PROP}
+  (APP: App.app) (E : coPset) (m : masks.t) γ : SepHandler PROP (App.evt APP) :=
+  {| do := Step.gen_requester APP E m γ |}%I.
 
 
 (** The step relation for a simple LTS that uses [bs] as the state.

--- a/rocq-brick-libstdcpp/test/g4g/prelude.v
+++ b/rocq-brick-libstdcpp/test/g4g/prelude.v
@@ -203,19 +203,6 @@ Section to_spectra.
   Proof. clear. solve_learnable. Qed.
   Hint Resolve authset_frag_exact_learn : sl_opacity.
 
-
-  (* The early commit version
-  #[program]
-  Definition requester_ec_C (app : App.app) (s : _) s' evt :=
-    \cancelx
-    \using{γ} AuthSet.frag γ {[s]}
-    \proving{E K} Step.requester app E γ {[ evt ]} K
-    \through{s'} [| AnyStep app.(App.lts).(Sts._step) {[s]} evt s' |]
-    \through AuthSet.frag γ s' -∗ K evt
-    \end@{mpredI}.
-  Next Obligation. Abort.
-  *)
-
   Lemma default_masks_valid : masks.valid masks.default (⊤ ∖ ↑refinement_rootNS).
   Proof. red. set_solver. Qed.
 
@@ -396,6 +383,7 @@ Definition AppHandler {PROP : bi} {HasFupd : BiFUpd PROP} {HasGhost : prop_const
 Section app_handler_hints.
   Context `{Σ : cpp_logic}.
   Context `{SPECTRA : @appG evt lts _Σ}.
+
 
   #[program]
   Definition gen_bs_dos_steps_C (lts : _) inG

--- a/rocq-brick-libstdcpp/test/g4g/prelude.v
+++ b/rocq-brick-libstdcpp/test/g4g/prelude.v
@@ -68,7 +68,8 @@ Section operational.
       is reachable which is necessary for soundness.
    *)
   Class AnyStep  (Pre : propset T) (evt : option E) (Post : propset T) : Prop :=
-  { _safe : forall s, s ∈ Pre -> exists s', step s evt s' /\ s' ∈ Post
+  { _non_empty : exists s, s ∈ Pre
+  ; _safe : forall s, s ∈ Pre -> exists s', step s evt s' /\ s' ∈ Post
   ; _steps_to : forall s', s' ∈ Post -> ∃ s, s ∈ Pre /\ step s evt s' }.
 
   (** The transitive generalization of [AnyStep].
@@ -78,50 +79,51 @@ Section operational.
       e.g. such as an interaction tree.
    *)
   Inductive AnySteps (Pre : propset T) : list E -> propset T -> Prop :=
-  | Finish {Post} {_ : ∅ ⊂ Post} (_ : Post ⊆ Pre) : AnySteps Pre [] Post
+  | Finish {_ : exists s, s ∈ Pre} : AnySteps Pre [] Pre
   | Step {evt evts Mid Post}
       (_ : AnyStep Pre (Some evt) Mid)
       (_ : AnySteps Mid evts Post)
     : AnySteps Pre (evt :: evts) Post
+(*
   | Tau {evts Mid Post}
+      (* Tau events are not stored in the trace *)
       (_ : AnyStep Pre None Mid)
       (_ : AnySteps Mid evts Post)
     : AnySteps Pre evts Post
-  | Refine {Pre'} {_ : ∅ ⊂ Pre} (_ : Pre' ⊆ Pre) {es Post} :
+*)
+  | Refine {Pre'} (_ : Pre' ⊆ Pre) {_ : exists s, s ∈ Pre'}  {es Post} :
     AnySteps Pre' es Post -> AnySteps Pre es Post.
 
   Lemma AnySteps_mono_post Pre evts Post Post' :
-    ∅ ⊂ Post' ⊆ Post ->
+    Post' ⊆ Post ->
+    (exists s, s ∈ Post') ->
     AnySteps Pre evts Post ->
     AnySteps Pre evts Post'.
-  Proof.
-    induction 2; eauto using AnySteps.
-    constructor; set_solver.
-  Qed.
+  Proof. induction 3; eauto using AnySteps. Qed.
 
-  Lemma AnySteps_mono_pre Pre Pre' evts Post :
+  Lemma AnySteps_mono_pre Pre' {Pre evts Post} :
     (* ∅ ⊂ Pre' ⊆ Pre ->
     AnySteps Pre evts Post ->
     AnySteps Pre' evts Post. *)
-    ∅ ⊂ Pre ->
     Pre' ⊆ Pre ->
     AnySteps Pre' evts Post ->
+    (exists x, x ∈ Pre') ->
     AnySteps Pre evts Post.
-  Proof. intros. exact: Refine. Qed.
+  Proof. intros. eapply Refine; eauto. Qed.
 
   Lemma AnyStep_invert_nonempty Pre evt Post :
     AnyStep Pre evt Post ->
-    ∅ ⊂ Post <-> ∅ ⊂ Pre.
+    (exists x, x ∈ Pre) /\ (exists x, x ∈ Post).
   Proof. intros []; set_solver. Qed.
 
   Lemma AnySteps_invert_nonempty Pre evts Post :
     AnySteps Pre evts Post ->
-    ∅ ⊂ Post /\ ∅ ⊂ Pre.
+    (exists x, x ∈ Pre) /\ (exists x, x ∈ Post).
   Proof.
     induction 1; intuition.
-    - set_solver.
-    - by rewrite -AnyStep_invert_nonempty.
-    - by rewrite -AnyStep_invert_nonempty.
+    - by destruct H.
+(*    - by destruct H. *)
+    - destruct H0 as [x ?]; exists x. eapply elem_of_subseteq; eauto.
   Qed.
 End operational.
 Existing Class AnySteps.
@@ -216,15 +218,14 @@ Section to_spectra.
   Next Obligation. Abort.
   *)
 
-  #[program]
-  Definition requester_C {_ : BiBUpdFUpd PROP} (app : App.app) (s : _) s' evt
-    (ANY_STEP : AnyStep app.(App.lts).(Sts._step) {[s]} (Some evt) s'):=
-    \cancelx
-    \using{γ} AuthSet.frag γ {[s]}
-    \proving{E K} Step.requester app E γ {[ evt ]} K
-    \through AuthSet.frag γ s' -∗ K evt
-    \end@{PROP}.
-  Next Obligation.
+  Lemma default_masks_valid : masks.valid masks.default (⊤ ∖ ↑refinement_rootNS).
+  Proof. red. set_solver. Qed.
+
+  Lemma requester_anystep {_ : BiBUpdFUpd PROP} (app : App.app) (s : _) s' e
+    (ANY_STEP : AnyStep app.(App.lts).(Sts._step) {[s]} (Some e) s') γ :
+    AuthSet.frag γ {[s]}
+    ⊢ ∀ E K, (AuthSet.frag γ s' -∗ K e)%I -∗ Step.requester app E γ {[ e ]} K.
+  Proof.
     intros.
     work.
     rewrite /Step.requester.
@@ -239,18 +240,71 @@ Section to_spectra.
     iSplitR.
     { iPureIntro.
       intros. destruct ANY_STEP.
-      inversion H; subst. edestruct _safe0. done. intuition; eauto. }
+      inversion H0; subst. edestruct _safe0. done. intuition; eauto. }
     iIntros (?) "[% Hfrag]". iMod "Hclose".
     work.
     iApply bupd_fupd.
     iDestruct (AuthSet.frag_upd with "Hfrag") as ">Hfrag"; last by iModIntro; iFrame.
     inversion ANY_STEP.
-    inversion H; subst; clear H.
+    inversion H0; subst; clear H0.
     intros ? Hin. apply _steps_to0 in Hin.
     inversion Hin as [?[??]].
-    inversion H; subst. done.
+    inversion H0; subst. done.
   Qed.
+
+  (* NOTE: These definitions do not work as hints due to unfication failures *)
+  #[program]
+  Definition requester_C {_ : BiBUpdFUpd PROP} (app : App.app) (s : _) s' evt
+    (ANY_STEP : AnyStep app.(App.lts).(Sts._step) {[s]} (Some evt) s'):=
+    \cancelx
+    \using{γ} AuthSet.frag γ {[s]}
+    \proving{E K} Step.requester app E γ {[ evt ]} K
+    \through AuthSet.frag γ s' -∗ K evt
+    \end@{PROP}.
+  Next Obligation. intros. by apply requester_anystep. Qed.
   Hint Resolve requester_C : sl_opacity.
+
+  Lemma gen_requester_anystep {_ : BiBUpdFUpd PROP} (app : App.app) (s : _) s' e
+    (ANY_STEP : AnyStep app.(App.lts).(Sts._step) s (Some e) s') γ :
+    AuthSet.frag γ s
+    ⊢ ∀ E m (_ : masks.valid m E) K, (AuthSet.frag γ s' -∗ K e)%I -∗ Step.gen_requester app E m γ {[ e ]} K.
+  Proof.
+    intros.
+    work.
+    lazymatch goal with H : masks.valid _ _ |- _ => rename H into Hvalid end.
+    iAcIntro.
+    rewrite /commit_acc.
+    simpl.
+    iApply fupd_mask_weaken; [| iIntros "Hclose"; iModIntro ].
+    { clear -Hvalid; destruct Hvalid. set_solver. }
+    work.
+    iExists s. work.
+    iSplitR.
+    { iPureIntro. split.
+      { apply AnyStep_invert_nonempty in ANY_STEP. tauto. }
+      intros. destruct ANY_STEP.
+      inversion H1; subst. edestruct _safe0. done. intuition; eauto. }
+    iIntros (?) "[% Hfrag]". iMod "Hclose".
+    work.
+    iApply bupd_fupd.
+    iDestruct (AuthSet.frag_upd with "Hfrag") as ">Hfrag"; last by iModIntro; iFrame.
+    inversion ANY_STEP.
+    inversion H0; subst; clear H0.
+    intros ? Hin. apply _steps_to0 in Hin.
+    inversion Hin as [?[??]].
+    apply elem_of_PropSet. eexists; intuition eauto.
+  Qed.
+
+  #[program]
+  Definition gen_requester_C {_ : BiBUpdFUpd PROP} (app : App.app) (s : _) s' evt
+    (ANY_STEP : AnyStep app.(App.lts).(Sts._step) s (Some evt) s'):=
+    \cancelx
+    \using{γ} AuthSet.frag γ s
+    \proving{E m (_ : masks.valid m E) K} Step.gen_requester app E m γ {[ evt ]} K
+    \through AuthSet.frag γ s' -∗ K evt
+    \end@{PROP}.
+  Next Obligation. intros. erewrite gen_requester_anystep; eauto. Qed.
+  Hint Resolve gen_requester_C : sl_opacity.
 
 End to_spectra.
 #[global] Hint Resolve frag_frag_exact_B frag_frag_exact_F : sl_opacity.
@@ -310,6 +364,46 @@ Definition AppHandler {PROP : bi} {HasFupd : BiFUpd PROP} {HasGhost : prop_const
   (APP: App.app) (E : coPset) (m : masks.t) γ : SepHandler PROP (App.evt APP) :=
   {| do := Step.gen_requester APP E m γ |}%I.
 
+Section app_handler_hints.
+  Context `{Σ : cpp_logic}.
+  Context `{SPECTRA : @appG evt lts _Σ}.
+
+  #[program]
+  Definition gen_bs_dos_steps_C (lts : _) inG
+    (APP := {| App.evt := output_event
+             ; App.lts := lts
+             ; App.inG := inG |})
+    (str : bs) (s s' : propset (Sts._state (App.lts _)))
+    (ANY_STEPS : AnySteps APP.(App.lts).(Sts._step) s ((fun x => Write x) <$> BS.string_to_bytes str) s') :=
+    \cancelx
+    \using{γ} AuthSet.frag γ s
+    \proving{K : mpredI} ostream.bs_dos (AppHandler APP (⊤ ∖ ↑refinement_rootNS) masks.default γ) str K
+    \through (AuthSet.frag γ s' -∗ K)
+    \end@{mpredI}.
+  Next Obligation.
+    simpl. clear.
+    intros ? ? str s s' ANY_STEPS.
+    remember ((fun x => Write x) <$> BS.string_to_bytes str) as X.
+    generalize dependent str.
+    induction ANY_STEPS; simpl.
+    { destruct str; simpl; try congruence.
+      intros. iIntros "f" (?) "k". iApply "k"; done. }
+    { destruct str; simpl; try congruence.
+      inversion 1; subst; intros.
+      iIntros "f" (?) "k".
+      eapply (gen_requester_anystep {| App.evt := output_event; App.lts := lts0; App.inG := inG |}) in H.
+      iDestruct (H with "f") as "X"; clear H.
+      iApply "X".
+      { iPureIntro. exact default_masks_valid. }
+      { iIntros "!> f". iApply (IHANY_STEPS with "f k"). } }
+    { intros; subst.
+      iIntros "f" (?) "k".
+      iDestruct (AuthSet.frag_upd with "f") as ">X"; first done.
+      by iApply (IHANY_STEPS with "X"). }
+  Qed.
+
+End app_handler_hints.
+
 
 (** * Output Applications *)
 
@@ -331,7 +425,8 @@ Instance only_output_any_step {c cs}
   : AnyStep only_output {[ BS.String c cs ]}
       (Some $ Write $ Byte.to_N c) {[ cs ]}.
 Proof.
-  constructor; inversion 1; subst.
+  constructor; try inversion 1; subst.
+  { set_solver. }
   { eexists; constructor => //. }
   { eexists; repeat constructor. }
 Qed.
@@ -351,6 +446,7 @@ Proof.
   { simpl.
     econstructor; [ | eapply IHstr' ].
     { constructor.
+      { set_solver. }
       { intros. exists (str' ++ rest)%bs.
         inversion H; subst.
         have->: (BS.String b str' ++ rest = BS.String b (str' ++ rest))%bs by done.

--- a/rocq-brick-libstdcpp/test/g4g/prelude.v
+++ b/rocq-brick-libstdcpp/test/g4g/prelude.v
@@ -311,13 +311,20 @@ Definition AppHandler {PROP : bi} {HasFupd : BiFUpd PROP} {HasGhost : prop_const
   {| do := Step.gen_requester APP E m γ |}%I.
 
 
+(** * Output Applications *)
+
 (** The step relation for a simple LTS that uses [bs] as the state.
 
     This LTS only supports output transitions.
  *)
 Inductive only_output : bs -> option output_event -> bs -> Prop :=
-| output_char {c} {b : bs} : only_output (BS.String c b) (Some $ Write $ Byte.to_N c) b
-| skip {bs} : only_output bs None bs.
+| output_char {c} {b : bs} : only_output (BS.String c b) (Some $ Write $ Byte.to_N c) b.
+
+Definition output_app (init : bs -> Prop) : LTS output_event :=
+  {| Sts._state := bs
+   ; Sts._init_state := init
+   ; Sts._step := only_output |}.
+
 
 #[global]
 Instance only_output_any_step {c cs}
@@ -325,29 +332,8 @@ Instance only_output_any_step {c cs}
       (Some $ Write $ Byte.to_N c) {[ cs ]}.
 Proof.
   constructor; inversion 1; subst.
-  { eexists; constructor => //. constructor. }
+  { eexists; constructor => //. }
   { eexists; repeat constructor. }
-Qed.
-
-#[global]
-Instance final_any_steps {str str' : bs} :
-  str = str' ->
-  AnySteps only_output {[str]}
-      ((λ x : N, Write x) <$> BS.string_to_bytes (str'))
-      {[""%bs]}.
-Proof.
-  intros; subst.
-  clear.
-  induction str'.
-  { constructor; set_solver. }
-  { simpl.
-    econstructor; [ | eassumption ].
-    constructor.
-    { intros. exists str'.
-      inversion H; subst. constructor => //. constructor. }
-    { inversion 1; subst.
-      eexists _; split. set_solver.
-      constructor. } }
 Qed.
 
 #[global]
@@ -368,13 +354,20 @@ Proof.
       { intros. exists (str' ++ rest)%bs.
         inversion H; subst.
         have->: (BS.String b str' ++ rest = BS.String b (str' ++ rest))%bs by done.
-        constructor => //. constructor. }
+        constructor => //. }
       { inversion 1; subst.
         eexists _; split. set_solver.
         constructor. } } }
 Qed.
 
-Definition output_app (init : bs -> Prop) : LTS output_event :=
-  {| Sts._state := bs
-   ; Sts._init_state := init
-   ; Sts._step := only_output |}.
+#[global]
+Instance final_any_steps {str str' : bs} :
+  str = str' ->
+  AnySteps only_output {[str]}
+      ((λ x : N, Write x) <$> BS.string_to_bytes (str'))
+      {[""%bs]}.
+Proof.
+  intros.
+  have->: str = (str ++ "")%bs by rewrite right_id.
+  by apply initial_any_steps.
+Qed.

--- a/rocq-brick-libstdcpp/test/g4g/prelude.v
+++ b/rocq-brick-libstdcpp/test/g4g/prelude.v
@@ -203,9 +203,6 @@ Section to_spectra.
   Proof. clear. solve_learnable. Qed.
   Hint Resolve authset_frag_exact_learn : sl_opacity.
 
-  Lemma default_masks_valid : masks.valid masks.default (⊤ ∖ ↑refinement_rootNS).
-  Proof. red. set_solver. Qed.
-
   Lemma use_updater APP E γ sset (_ : exists s, s ∈ sset) (_ : Step.tau_safe APP.(App.lts) sset) :
     Step.updater APP E γ
     ⊢ AuthSet.frag γ sset -∗
@@ -287,7 +284,7 @@ Section to_spectra.
   Proof.
     intros.
     work.
-    lazymatch goal with H : masks.valid _ _ |- _ => rename H into Hvalid end.
+    ren_hyp Hvalid (masks.valid _ _).
     iAcIntro.
     rewrite /commit_acc.
     simpl.
@@ -405,15 +402,16 @@ Section app_handler_hints.
     generalize dependent str.
     induction ANY_STEPS; simpl.
     { destruct str; simpl; try congruence.
-      intros. iIntros "[f #_]" (?) "k". iApply "k"; done. }
+      intros. iIntros "[f #_]" (?) "k". iModIntro. iApply "k"; done. }
     { destruct str; simpl; try congruence.
       inversion 1; subst; intros.
       iIntros "[f #u]" (?) "k".
       eapply (gen_requester_anystep APP) in H.
       iDestruct (H with "f") as "X"; clear H.
+      iModIntro.
       iApply "X".
-      { iPureIntro. exact default_masks_valid. }
-      { iIntros "!> f". iApply (IHANY_STEPS with "[f u] k"). iFrame "#∗". } }
+      { iPureIntro. red. set_solver. }
+      { iIntros "f". iApply (IHANY_STEPS with "[f u] k"). iFrame "#∗". } }
     { (* tau *)
       intros; subst.
       iIntros "[f #u]" (?) "k".
@@ -457,24 +455,22 @@ Proof.
 Qed.
 
 #[global]
-Instance initial_any_steps {str str' rest : bs} :
-  str = str' ->
+Instance initial_any_steps {str rest : bs} :
   AnySteps only_output {[str ++ rest]}%bs
-    ((λ x : N, Write x) <$> BS.string_to_bytes (str'))
+    ((λ x : N, Write x) <$> BS.string_to_bytes str)
     {[rest]}.
 Proof.
-  intros; subst.
   clear.
   revert rest.
-  induction str'.
+  induction str.
   { constructor; set_solver. }
   { simpl.
-    econstructor; [ | eapply IHstr' ].
+    econstructor; [ | eapply IHstr ].
     { constructor.
       { set_solver. }
-      { intros. exists (str' ++ rest)%bs.
+      { intros. exists (str ++ rest)%bs.
         inversion H; subst.
-        have->: (BS.String b str' ++ rest = BS.String b (str' ++ rest))%bs by done.
+        have->: (BS.String b str ++ rest = BS.String b (str ++ rest))%bs by done.
         constructor => //. }
       { inversion 1; subst.
         eexists _; split. set_solver.
@@ -482,13 +478,13 @@ Proof.
 Qed.
 
 #[global]
-Instance final_any_steps {str str' : bs} :
-  str = str' ->
+Instance final_any_steps {str : bs} :
   AnySteps only_output {[str]}
-      ((λ x : N, Write x) <$> BS.string_to_bytes (str'))
+      ((λ x : N, Write x) <$> BS.string_to_bytes str)
       {[""%bs]}.
 Proof.
   intros.
-  have->: str = (str ++ "")%bs by rewrite right_id.
+  have H: str = (str ++ "")%bs by rewrite right_id.
+  rewrite {1}H.
   by apply initial_any_steps.
 Qed.


### PR DESCRIPTION
This closes the rest of the proofs and generalizes the definitions to support silent steps and refinements.

Input is still not well supported.