### PR TITLE
generate AST using docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ mutexes.pdf
 mutexes.synctex.gz
 comment.cut
 _RocqProject
+
+# Only at the root, since it comes from enabling `dune.disabled` locally
+/dune

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
 # brick-libcpp
+
 Specifications of the C++ standard library in BRiCk.
+
+## Development
+
+To develop on these specifications, contact Skylabs AI for access to our
+verification toolchain, and you a clang toolchain using the GNU C++ library (not
+clang's own version).
+
+With access to our release image, you can:
+- Open this repo in a devcontainer using our Docker release image; see `.devcontainer/README.md`.
+
+If you have access to our automation sources, you can check this out as part of
+https://github.com/SkyLabsAI/workspace. After `make vendored-pull fmdeps-pull`,
+you'll find a copy of this repository in `fmdeps/brick-libcpp`. Then:
+
+- on Linux, you can build this directly.
+- on any platform, you can route AST generation through our Docker image.
+To this end, edit `rocq-brick-libstdcpp/dune` from
+
+```
+(env
+ (_
+  ; Enable the following setting to build ASTs in container.
+  ; (env-vars
+  ;  (CPP2V_DOCKER_IMAGE "skylabsai/fm-releases:fm-release-nightly"))
+```
+
+to
+
+```
+(env
+ (_
+  ; Enable the following setting to build ASTs in container.
+  (env-vars
+   (CPP2V_DOCKER_IMAGE "skylabsai/fm-releases:fm-release-nightly"))
+```

--- a/README.md
+++ b/README.md
@@ -17,22 +17,7 @@ you'll find a copy of this repository in `fmdeps/brick-libcpp`. Then:
 
 - on Linux, you can build this directly.
 - on any platform, you can route AST generation through our Docker image.
-To this end, edit `rocq-brick-libstdcpp/dune` from
-
+To this end, go to `workspace` and run
 ```
-(env
- (_
-  ; Enable the following setting to build ASTs in container.
-  ; (env-vars
-  ;  (CPP2V_DOCKER_IMAGE "skylabsai/fm-releases:fm-release-nightly"))
-```
-
-to
-
-```
-(env
- (_
-  ; Enable the following setting to build ASTs in container.
-  (env-vars
-   (CPP2V_DOCKER_IMAGE "skylabsai/fm-releases:fm-release-nightly"))
+cd fmdeps/brick-libcpp; cp dune.disabled dune
 ```

--- a/dune.disabled
+++ b/dune.disabled
@@ -1,0 +1,15 @@
+; Copy as dune to enable
+
+(subdir rocq-brick-libstdcpp
+ ; hack: we can't add (env) here, so we only add it to subfolders
+ (subdir proof
+  (env
+   (_
+    (env-vars
+     (CPP2V_DOCKER_IMAGE "skylabsai/fm-releases:fm-release-nightly")))))
+
+ (subdir test
+  (env
+   (_
+    (env-vars
+     (CPP2V_DOCKER_IMAGE "skylabsai/fm-releases:fm-release-nightly"))))))

--- a/rocq-brick-libstdcpp/cpp2v_docker
+++ b/rocq-brick-libstdcpp/cpp2v_docker
@@ -11,9 +11,9 @@ if [[ -n "$CPP2V_DOCKER_IMAGE" ]]; then
 	ARGS+=( "--volume" "$DUNE_SOURCEROOT:$BRICK_LIBCPP" )
 	ARGS+=( "--workdir" "$BRICK_LIBCPP/$REL_PATH" )
 
-	CMD="$( printf '"%q" ' "$@" )" # ensure each argument is quoted as a whole.
+	cpp2v_args="$( printf '"%q" ' "$@" )" # ensure each argument is quoted as a whole.
 	docker run "${ARGS[@]}" "$CPP2V_DOCKER_IMAGE" \
-		/bin/bash -c 'eval $(opam env)'"; cpp2v $CMD"
+		/bin/bash -c 'eval $(opam env)'"; cpp2v $cpp2v_args"
 else
 	next=$DUNE_SOURCEROOT/_build/install/default/bin/cpp2v
 	[ -e $next ] || next='opam exec -- cpp2v'

--- a/rocq-brick-libstdcpp/cpp2v_docker
+++ b/rocq-brick-libstdcpp/cpp2v_docker
@@ -4,7 +4,6 @@ REALPATH=$(which grealpath || which realpath)
 REL_PATH="$($REALPATH `pwd` --relative-to "$DUNE_SOURCEROOT")"
 
 if [[ -n "$CPP2V_DOCKER_IMAGE" ]]; then
-	OPAM_ENV='$(opam env)'
 	BRICK_LIBCPP=/home/coq/worktree
 	ARGS=()
 	ARGS+=( "--platform" "linux/amd64" )
@@ -13,7 +12,8 @@ if [[ -n "$CPP2V_DOCKER_IMAGE" ]]; then
 	ARGS+=( "--workdir" "$BRICK_LIBCPP/$REL_PATH" )
 
 	CMD="$( printf '"%q" ' "$@" )" # ensure each argument is quoted as a whole.
-	docker run "${ARGS[@]}" "$CPP2V_DOCKER_IMAGE" /bin/bash -c "eval ${OPAM_ENV} ; cpp2v $CMD "
+	docker run "${ARGS[@]}" "$CPP2V_DOCKER_IMAGE" \
+		/bin/bash -c 'eval $(opam env)'"; cpp2v $CMD"
 else
 	next=$DUNE_SOURCEROOT/_build/install/default/bin/cpp2v
 	[ -e $next ] || next='opam exec -- cpp2v'

--- a/rocq-brick-libstdcpp/cpp2v_docker
+++ b/rocq-brick-libstdcpp/cpp2v_docker
@@ -17,5 +17,5 @@ if [[ -n "$CPP2V_DOCKER_IMAGE" ]]; then
 else
   next=$DUNE_SOURCEROOT/_build/install/default/bin/cpp2v
   [ -e $next ] || next='opam exec -- cpp2v'
-  $next "$@"
+  exec $next "$@"
 fi

--- a/rocq-brick-libstdcpp/cpp2v_docker
+++ b/rocq-brick-libstdcpp/cpp2v_docker
@@ -11,7 +11,8 @@ if [[ -n "$CPP2V_DOCKER_IMAGE" ]]; then
 	ARGS+=( "--volume" "${HOME}/.cache/remote_dune:/home/coq/.cache/dune:cached" )
 	ARGS+=( "--volume" "$DUNE_SOURCEROOT:$BRICK_LIBCPP" )
 	ARGS+=( "--workdir" "$BRICK_LIBCPP/$REL_PATH" )
-	CMD=$@
+
+	CMD="$( printf '"%q" ' "$@" )" # ensure each argument is quoted as a whole.
 	docker run "${ARGS[@]}" "$CPP2V_DOCKER_IMAGE" /bin/bash -c "eval ${OPAM_ENV} ; cpp2v $CMD "
 else
 	next=$DUNE_SOURCEROOT/_build/install/default/bin/cpp2v

--- a/rocq-brick-libstdcpp/cpp2v_docker
+++ b/rocq-brick-libstdcpp/cpp2v_docker
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-REL_PATH="$(grealpath `pwd` --relative-to "$DUNE_SOURCEROOT")"
+REALPATH=$(which grealpath || which realpath)
+REL_PATH="$($REALPATH `pwd` --relative-to "$DUNE_SOURCEROOT")"
 
 if [[ -n "$CPP2V_DOCKER_IMAGE" ]]; then
 	OPAM_ENV='$(opam env)'

--- a/rocq-brick-libstdcpp/cpp2v_docker
+++ b/rocq-brick-libstdcpp/cpp2v_docker
@@ -14,5 +14,7 @@ if [[ -n "$CPP2V_DOCKER_IMAGE" ]]; then
 	CMD=$@
 	docker run "${ARGS[@]}" "$CPP2V_DOCKER_IMAGE" /bin/bash -c "eval ${OPAM_ENV} ; cpp2v $CMD "
 else
-	cpp2v "$@"
+	next=$DUNE_SOURCEROOT/_build/install/default/bin/cpp2v
+	[ -e $next ] || next='opam exec -- cpp2v'
+	$next "$@"
 fi

--- a/rocq-brick-libstdcpp/cpp2v_docker
+++ b/rocq-brick-libstdcpp/cpp2v_docker
@@ -4,18 +4,18 @@ REALPATH=$(which grealpath || which realpath)
 REL_PATH="$($REALPATH `pwd` --relative-to "$DUNE_SOURCEROOT")"
 
 if [[ -n "$CPP2V_DOCKER_IMAGE" ]]; then
-	BRICK_LIBCPP=/home/coq/worktree
-	ARGS=()
-	ARGS+=( "--platform" "linux/amd64" )
-	ARGS+=( "--volume" "${HOME}/.cache/remote_dune:/home/coq/.cache/dune:cached" )
-	ARGS+=( "--volume" "$DUNE_SOURCEROOT:$BRICK_LIBCPP" )
-	ARGS+=( "--workdir" "$BRICK_LIBCPP/$REL_PATH" )
+  BRICK_LIBCPP=/home/coq/worktree
+  ARGS=()
+  ARGS+=( "--platform" "linux/amd64" )
+  ARGS+=( "--volume" "${HOME}/.cache/remote_dune:/home/coq/.cache/dune:cached" )
+  ARGS+=( "--volume" "$DUNE_SOURCEROOT:$BRICK_LIBCPP" )
+  ARGS+=( "--workdir" "$BRICK_LIBCPP/$REL_PATH" )
 
-	cpp2v_args="$( printf '"%q" ' "$@" )" # ensure each argument is quoted as a whole.
-	docker run "${ARGS[@]}" "$CPP2V_DOCKER_IMAGE" \
-		/bin/bash -c 'eval $(opam env)'"; cpp2v $cpp2v_args"
+  cpp2v_args="$( printf '"%q" ' "$@" )" # ensure each argument is quoted as a whole.
+  docker run "${ARGS[@]}" "$CPP2V_DOCKER_IMAGE" \
+          /bin/bash -c 'eval $(opam env)'"; cpp2v $cpp2v_args"
 else
-	next=$DUNE_SOURCEROOT/_build/install/default/bin/cpp2v
-	[ -e $next ] || next='opam exec -- cpp2v'
-	$next "$@"
+  next=$DUNE_SOURCEROOT/_build/install/default/bin/cpp2v
+  [ -e $next ] || next='opam exec -- cpp2v'
+  $next "$@"
 fi

--- a/rocq-brick-libstdcpp/cpp2v_docker
+++ b/rocq-brick-libstdcpp/cpp2v_docker
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+REL_PATH="$(grealpath `pwd` --relative-to "$DUNE_SOURCEROOT")"
+
+if [[ -n "$CPP2V_DOCKER_IMAGE" ]]; then
+	OPAM_ENV='$(opam env)'
+	BRICK_LIBCPP=/home/coq/worktree
+	ARGS=()
+	ARGS+=( "--platform" "linux/amd64" )
+	ARGS+=( "--volume" "${HOME}/.cache/remote_dune:/home/coq/.cache/dune:cached" )
+	ARGS+=( "--volume" "$DUNE_SOURCEROOT:$BRICK_LIBCPP" )
+	ARGS+=( "--workdir" "$BRICK_LIBCPP/$REL_PATH" )
+	CMD=$@
+	docker run "${ARGS[@]}" "$CPP2V_DOCKER_IMAGE" /bin/bash -c "eval ${OPAM_ENV} ; cpp2v $CMD "
+else
+	cpp2v "$@"
+fi

--- a/rocq-brick-libstdcpp/cpp2v_docker
+++ b/rocq-brick-libstdcpp/cpp2v_docker
@@ -3,6 +3,12 @@
 REALPATH=$(which grealpath || which realpath)
 REL_PATH="$($REALPATH `pwd` --relative-to "$DUNE_SOURCEROOT")"
 
+if [ -n "$IN_CPP2V_DOCKER" ]; then
+  echo "Error: recursive invocation of \"cpp2v_docker\" as $0 from outer cpp2v_docker as ${IN_CPP2V_DOCKER}"
+  echo "(PATH is $PATH)."
+  exit 1
+fi
+
 if [[ -n "$CPP2V_DOCKER_IMAGE" ]]; then
   BRICK_LIBCPP=/home/coq/worktree
   ARGS=()
@@ -15,6 +21,7 @@ if [[ -n "$CPP2V_DOCKER_IMAGE" ]]; then
   docker run "${ARGS[@]}" "$CPP2V_DOCKER_IMAGE" \
           /bin/bash -c 'eval $(opam env)'"; cpp2v $cpp2v_args"
 else
+  export IN_CPP2V_DOCKER="$0"
   next=$DUNE_SOURCEROOT/_build/install/default/bin/cpp2v
   [ -e $next ] || next='opam exec -- cpp2v'
   exec $next "$@"

--- a/rocq-brick-libstdcpp/dune
+++ b/rocq-brick-libstdcpp/dune
@@ -1,8 +1,5 @@
 (env
  (_
-  ;; Enable the following setting to build ASTs in container.
-  ; (env-vars
-  ;  (CPP2V_DOCKER_IMAGE "skylabsai/fm-releases:fm-release-nightly"))
   (binaries
    (cpp2v_docker as cpp2v))
   (flags :standard %{read-lines:flags/ocamlc})

--- a/rocq-brick-libstdcpp/dune
+++ b/rocq-brick-libstdcpp/dune
@@ -1,5 +1,7 @@
 (env
  (_
+  (binaries
+   (cpp2v_docker as cpp2v))
   (flags :standard %{read-lines:flags/ocamlc})
   (ocamlopt_flags :standard -O3 -unbox-closures)
   (rocq

--- a/rocq-brick-libstdcpp/dune
+++ b/rocq-brick-libstdcpp/dune
@@ -1,5 +1,8 @@
 (env
  (_
+  ;; Enable the following setting to build ASTs in container.
+  ; (env-vars
+  ;  (CPP2V_DOCKER_IMAGE "skylabsai/fm-releases:fm-release-nightly"))
   (binaries
    (cpp2v_docker as cpp2v))
   (flags :standard %{read-lines:flags/ocamlc})

--- a/rocq-brick-libstdcpp/proof/cpp2v-dune-gen.sh
+++ b/rocq-brick-libstdcpp/proof/cpp2v-dune-gen.sh
@@ -60,6 +60,7 @@ outRule() {
 		 (alias test_ast)
 		 (deps
 		  (:input ${name}.${ext})
+		  (env_var CPP2V_DOCKER_IMAGE)
 		  (glob_files_rec ${prefix}*.hpp)${universe})
 		 (action
 		 	 (with-stderr-to ${module}.stderr ${action})))

--- a/rocq-brick-libstdcpp/proof/cpp2v-dune-gen.sh
+++ b/rocq-brick-libstdcpp/proof/cpp2v-dune-gen.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# -*- indent-tabs-mode: t; sh-basic-offset: 8 -*- vim:set noet sw=8:
 
 usage() {
 	cat >&2 <<-EOF
@@ -131,5 +132,3 @@ path="$1"
 shift
 
 traverse "" "$path" "$@"
-
-# vim:set noet sw=8:

--- a/rocq-brick-libstdcpp/proof/cpp2v-dune-gen.sh
+++ b/rocq-brick-libstdcpp/proof/cpp2v-dune-gen.sh
@@ -58,7 +58,9 @@ outRule() {
 		(rule
 		 (targets ${module}.stderr ${targ})
 		 (alias test_ast)
-		 (deps (:input ${name}.${ext}) (glob_files_rec ${prefix}*.hpp)${universe})
+		 (deps
+		  (:input ${name}.${ext})
+		  (glob_files_rec ${prefix}*.hpp)${universe})
 		 (action
 		 	 (with-stderr-to ${module}.stderr ${action})))
 		(alias (name srcs) (deps ${name}.${ext}))

--- a/rocq-brick-libstdcpp/proof/dune.inc
+++ b/rocq-brick-libstdcpp/proof/dune.inc
@@ -3,7 +3,10 @@
  (rule
   (targets inc_algorithms_cpp.v.stderr inc_algorithms_cpp.v inc_algorithms_cpp_templates.v)
   (alias test_ast)
-  (deps (:input inc_algorithms.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input inc_algorithms.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to inc_algorithms_cpp.v.stderr (run cpp2v -v %{input} -o inc_algorithms_cpp.v --no-elaborate --templates=inc_algorithms_cpp_templates.v  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps inc_algorithms.cpp))
@@ -12,7 +15,10 @@
  (rule
   (targets inc_cassert_cpp.v.stderr inc_cassert_cpp.v)
   (alias test_ast)
-  (deps (:input inc_cassert.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input inc_cassert.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to inc_cassert_cpp.v.stderr (run cpp2v -v %{input} -o inc_cassert_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps inc_cassert.cpp))
@@ -21,7 +27,10 @@
  (rule
   (targets inc_cctype_cpp.v.stderr inc_cctype_cpp.v)
   (alias test_ast)
-  (deps (:input inc_cctype.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input inc_cctype.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to inc_cctype_cpp.v.stderr (run cpp2v -v %{input} -o inc_cctype_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps inc_cctype.cpp))
@@ -30,7 +39,10 @@
  (rule
   (targets inc_cstdlib_cpp.v.stderr inc_cstdlib_cpp.v)
   (alias test_ast)
-  (deps (:input inc_cstdlib.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input inc_cstdlib.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to inc_cstdlib_cpp.v.stderr (run cpp2v -v %{input} -o inc_cstdlib_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps inc_cstdlib.cpp))
@@ -39,7 +51,10 @@
  (rule
   (targets inc_cstring_cpp.v.stderr inc_cstring_cpp.v)
   (alias test_ast)
-  (deps (:input inc_cstring.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input inc_cstring.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to inc_cstring_cpp.v.stderr (run cpp2v -v %{input} -o inc_cstring_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps inc_cstring.cpp))
@@ -48,7 +63,10 @@
  (rule
   (targets inc_iostream_cpp.v.stderr inc_iostream_cpp.v)
   (alias test_ast)
-  (deps (:input inc_iostream.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input inc_iostream.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to inc_iostream_cpp.v.stderr (run cpp2v -v %{input} -o inc_iostream_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps inc_iostream.cpp))
@@ -57,7 +75,10 @@
  (rule
   (targets inc_iostream_cpp.v.stderr inc_iostream_cpp.v)
   (alias test_ast)
-  (deps (:input inc_iostream.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input inc_iostream.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to inc_iostream_cpp.v.stderr (run cpp2v -v %{input} -o inc_iostream_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps inc_iostream.cpp))
@@ -66,7 +87,10 @@
  (rule
   (targets demo_cpp.v.stderr demo_cpp.v)
   (alias test_ast)
-  (deps (:input demo.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input demo.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to demo_cpp.v.stderr (run cpp2v -v %{input} -o demo_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps demo.cpp))
@@ -75,7 +99,10 @@
  (rule
   (targets inc_hpp.v.stderr inc_hpp.v)
   (alias test_ast)
-  (deps (:input inc.hpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input inc.hpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to inc_hpp.v.stderr (run cpp2v -v %{input} -o inc_hpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps inc.hpp))
@@ -84,7 +111,10 @@
  (rule
   (targets inc_new_cpp.v.stderr inc_new_cpp.v)
   (alias test_ast)
-  (deps (:input inc_new.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input inc_new.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to inc_new_cpp.v.stderr (run cpp2v -v %{input} -o inc_new_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps inc_new.cpp))
@@ -93,7 +123,10 @@
  (rule
   (targets inc_hpp.v.stderr inc_hpp.v)
   (alias test_ast)
-  (deps (:input inc.hpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input inc.hpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to inc_hpp.v.stderr (run cpp2v -v %{input} -o inc_hpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps inc.hpp))
@@ -102,7 +135,10 @@
  (rule
   (targets test_cpp.v.stderr test_cpp.v)
   (alias test_ast)
-  (deps (:input test.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input test.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to test_cpp.v.stderr (run cpp2v -v %{input} -o test_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps test.cpp))
@@ -111,7 +147,10 @@
  (rule
   (targets inc_string_cpp.v.stderr inc_string_cpp.v)
   (alias test_ast)
-  (deps (:input inc_string.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input inc_string.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to inc_string_cpp.v.stderr (run cpp2v -v %{input} -o inc_string_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps inc_string.cpp))
@@ -120,7 +159,10 @@
  (rule
   (targets inc_vector_cpp.v.stderr inc_vector_cpp.v inc_vector_cpp_templates.v)
   (alias test_ast)
-  (deps (:input inc_vector.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input inc_vector.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to inc_vector_cpp.v.stderr (run cpp2v -v %{input} -o inc_vector_cpp.v --no-elaborate --templates=inc_vector_cpp_templates.v  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps inc_vector.cpp))

--- a/rocq-brick-libstdcpp/test/dune.inc
+++ b/rocq-brick-libstdcpp/test/dune.inc
@@ -3,7 +3,10 @@
  (rule
   (targets test_cpp.v.stderr test_cpp.v)
   (alias test_ast)
-  (deps (:input test.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input test.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to test_cpp.v.stderr (run cpp2v -v %{input} -o test_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps test.cpp))
@@ -12,7 +15,10 @@
  (rule
   (targets test_cpp.v.stderr test_cpp.v)
   (alias test_ast)
-  (deps (:input test.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input test.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to test_cpp.v.stderr (run cpp2v -v %{input} -o test_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps test.cpp))
@@ -21,7 +27,10 @@
  (rule
   (targets test_cpp.v.stderr test_cpp.v)
   (alias test_ast)
-  (deps (:input test.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input test.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to test_cpp.v.stderr (run cpp2v -v %{input} -o test_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps test.cpp))
@@ -30,7 +39,10 @@
  (rule
   (targets N12_area_cpp.v.stderr N12_area_cpp.v)
   (alias test_ast)
-  (deps (:input N12_area.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input N12_area.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to N12_area_cpp.v.stderr (run cpp2v -v %{input} -o N12_area_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps N12_area.cpp))
@@ -39,7 +51,10 @@
  (rule
   (targets N1_hello_world_cpp.v.stderr N1_hello_world_cpp.v)
   (alias test_ast)
-  (deps (:input N1_hello_world.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input N1_hello_world.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to N1_hello_world_cpp.v.stderr (run cpp2v -v %{input} -o N1_hello_world_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps N1_hello_world.cpp))
@@ -48,7 +63,10 @@
  (rule
   (targets N4_sum_cpp.v.stderr N4_sum_cpp.v)
   (alias test_ast)
-  (deps (:input N4_sum.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input N4_sum.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to N4_sum_cpp.v.stderr (run cpp2v -v %{input} -o N4_sum_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps N4_sum.cpp))
@@ -57,7 +75,10 @@
  (rule
   (targets N4_sum_a_cpp.v.stderr N4_sum_a_cpp.v)
   (alias test_ast)
-  (deps (:input N4_sum_a.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input N4_sum_a.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to N4_sum_a_cpp.v.stderr (run cpp2v -v %{input} -o N4_sum_a_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps N4_sum_a.cpp))
@@ -66,7 +87,10 @@
  (rule
   (targets N5_swap_cpp.v.stderr N5_swap_cpp.v)
   (alias test_ast)
-  (deps (:input N5_swap.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input N5_swap.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to N5_swap_cpp.v.stderr (run cpp2v -v %{input} -o N5_swap_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps N5_swap.cpp))
@@ -75,7 +99,10 @@
  (rule
   (targets N5_swap_a_cpp.v.stderr N5_swap_a_cpp.v)
   (alias test_ast)
-  (deps (:input N5_swap_a.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input N5_swap_a.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to N5_swap_a_cpp.v.stderr (run cpp2v -v %{input} -o N5_swap_a_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps N5_swap_a.cpp))
@@ -84,7 +111,10 @@
  (rule
   (targets N6_print_sizeof_cpp.v.stderr N6_print_sizeof_cpp.v)
   (alias test_ast)
-  (deps (:input N6_print_sizeof.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input N6_print_sizeof.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to N6_print_sizeof_cpp.v.stderr (run cpp2v -v %{input} -o N6_print_sizeof_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps N6_print_sizeof.cpp))
@@ -93,7 +123,10 @@
  (rule
   (targets N12_area_cpp.v.stderr N12_area_cpp.v)
   (alias test_ast)
-  (deps (:input N12_area.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input N12_area.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to N12_area_cpp.v.stderr (run cpp2v -v %{input} -o N12_area_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps N12_area.cpp))
@@ -102,7 +135,10 @@
  (rule
   (targets N1_hello_world_cpp.v.stderr N1_hello_world_cpp.v)
   (alias test_ast)
-  (deps (:input N1_hello_world.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input N1_hello_world.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to N1_hello_world_cpp.v.stderr (run cpp2v -v %{input} -o N1_hello_world_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps N1_hello_world.cpp))
@@ -111,7 +147,10 @@
  (rule
   (targets N4_sum_cpp.v.stderr N4_sum_cpp.v)
   (alias test_ast)
-  (deps (:input N4_sum.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input N4_sum.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to N4_sum_cpp.v.stderr (run cpp2v -v %{input} -o N4_sum_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps N4_sum.cpp))
@@ -120,7 +159,10 @@
  (rule
   (targets N4_sum_a_cpp.v.stderr N4_sum_a_cpp.v)
   (alias test_ast)
-  (deps (:input N4_sum_a.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input N4_sum_a.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to N4_sum_a_cpp.v.stderr (run cpp2v -v %{input} -o N4_sum_a_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps N4_sum_a.cpp))
@@ -129,7 +171,10 @@
  (rule
   (targets N5_swap_cpp.v.stderr N5_swap_cpp.v)
   (alias test_ast)
-  (deps (:input N5_swap.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input N5_swap.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to N5_swap_cpp.v.stderr (run cpp2v -v %{input} -o N5_swap_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps N5_swap.cpp))
@@ -138,7 +183,10 @@
  (rule
   (targets N5_swap_a_cpp.v.stderr N5_swap_a_cpp.v)
   (alias test_ast)
-  (deps (:input N5_swap_a.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input N5_swap_a.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to N5_swap_a_cpp.v.stderr (run cpp2v -v %{input} -o N5_swap_a_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps N5_swap_a.cpp))
@@ -147,7 +195,10 @@
  (rule
   (targets N6_print_sizeof_cpp.v.stderr N6_print_sizeof_cpp.v)
   (alias test_ast)
-  (deps (:input N6_print_sizeof.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input N6_print_sizeof.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to N6_print_sizeof_cpp.v.stderr (run cpp2v -v %{input} -o N6_print_sizeof_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps N6_print_sizeof.cpp))
@@ -156,7 +207,10 @@
  (rule
   (targets guard_recursive_cpp.v.stderr guard_recursive_cpp.v)
   (alias test_ast)
-  (deps (:input guard_recursive.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input guard_recursive.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to guard_recursive_cpp.v.stderr (run cpp2v -v %{input} -o guard_recursive_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps guard_recursive.cpp))
@@ -165,7 +219,10 @@
  (rule
   (targets test_cpp.v.stderr test_cpp.v)
   (alias test_ast)
-  (deps (:input test.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input test.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to test_cpp.v.stderr (run cpp2v -v %{input} -o test_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps test.cpp))
@@ -174,7 +231,10 @@
  (rule
   (targets demo_cpp.v.stderr demo_cpp.v)
   (alias test_ast)
-  (deps (:input demo.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input demo.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to demo_cpp.v.stderr (run cpp2v -v %{input} -o demo_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps demo.cpp))
@@ -183,7 +243,10 @@
  (rule
   (targets test_cpp.v.stderr test_cpp.v)
   (alias test_ast)
-  (deps (:input test.cpp) (glob_files_rec ../*.hpp))
+  (deps
+   (:input test.cpp)
+   (env_var CPP2V_DOCKER_IMAGE)
+   (glob_files_rec ../*.hpp))
   (action
   	 (with-stderr-to test_cpp.v.stderr (run cpp2v -v %{input} -o test_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps test.cpp))


### PR DESCRIPTION
This changes the `cpp2v-dune-gen.sh` script so that the dune files call a wrapper called `cpp2v_docker` instead of `cpp2v` directly. 

The wrapper, `cpp2v_docker` uses the environment variable `CPP2V_DOCKER_IMAGE` to decide whether to use `docker` or not and to specify the name of the docker image to use. It can be turned on in a build by adding the following line in `dune-workspace`:

```
(env
  (_ (env-vars ("CPP2V_DOCKER_IMAGE" "ghcr.io/skylabsai/ci:fm-release"))))
```