### PR TITLE
Work on guard_recursive.cpp example

### DIFF
--- a/rocq-brick-libstdcpp/proof/mutex/spec/recursive_mutex.v
+++ b/rocq-brick-libstdcpp/proof/mutex/spec/recursive_mutex.v
@@ -223,7 +223,7 @@ cinv (
     (* TODO: add here sequential ownership of the lock, and maybe replace I by the lock invariant.
     Something like *)
     (* _mutex_field |-> mutex.R q ... ** *)
-    cinv_own γ.(inv_gname) q.
+    pureR (cinv_own γ.(inv_gname) q).
   #[only(cfractional,ascfractional,timeless,type_ptr="std::recursive_mutex")] derive R.
 
 
@@ -524,7 +524,7 @@ cinv (
       \prepost{q} this |-> R g.(lock_gname) q
       \pre{th n args} acquireable g th (Held n args) P
       \pre{q'} given_token g.(lock_gname) q'
-      \post token g.(lock_gname) q' ** ▷ acquireable g th (release $ Held n args) P).
+      \post token g.(lock_gname) q' ** acquireable g th (release $ Held n args) P).
 
     Definition do_lock g K : mpred := ∃ TT P th n q',
       inv_rmutex g (∃ xs, tele_app (TT := TT) P xs)
@@ -545,7 +545,7 @@ cinv (
       ** (
         (* TODO readd *)
         (* ▷ *)
-        (token g.(lock_gname) q' ** ▷ acquireable g th (release $ Held n args) P) -*
+        (token g.(lock_gname) q' ** acquireable g th (release $ Held n args) P) -*
         K).
     #[global] Arguments do_unlock /.
 
@@ -648,7 +648,7 @@ cinv (
       unlock_spec |-- unlock_spec'.
     Proof using MOD HOV HOU.
       apply specify_mono; work.
-      iExists _, (▷ acquireable g th (release $ Held n args) P)%I.
+      iExists _, (acquireable g th (release $ Held n args) P)%I.
       work.
       iAcIntro; rewrite /commit_acc/=.
       rewrite inv_rmutex.unlock acquireable.unlock.

--- a/rocq-brick-libstdcpp/proof/mutex/spec/recursive_mutex.v
+++ b/rocq-brick-libstdcpp/proof/mutex/spec/recursive_mutex.v
@@ -290,7 +290,10 @@ cinv (
 
   (** * Derived construction *)
   Record rmutex_gname :=
-    { lock_gname : gname; level_gname : iprop.gname }.
+    { lock_gname : gname
+    ; level_gname : iprop.gname
+    (* ; cinv_gname : iprop.gname *)
+    }.
   Definition rmutex_namespace := nroot .@@ "std" .@@ "recursive_mutex" .@@ "derived".
 
   Canonical Structure cmraR := (excl_authR (prodO natO thread_idTO)).
@@ -299,6 +302,8 @@ cinv (
   Definition inv_rmutex
       `{Σ : cpp_logic} `{!lockedG Σ} `{!HasOwn (iPropI _) cmraR}
       (g : rmutex_gname) (P : mpred) : mpred :=
+    (* TODO: this should be a _cancellable_ invariant *)
+    (* cinv rmutex_namespace g.(cinv_gname) *)
     inv rmutex_namespace
       (Exists n th, own g.(level_gname) (●E (n, th)) **
         match n with
@@ -306,6 +311,15 @@ cinv (
         | S n => locked g.(lock_gname) th (S n)
         end).
   #[only(knowledge)] derive inv_rmutex.
+
+  (*
+  sl.lock
+  Definition cinv_own_rmutex
+      `{Σ : cpp_logic} `{!lockedG Σ}
+      (g : rmutex_gname) (q : Qp) : mpred :=
+    cinv_own g.(cinv_gname) q.
+    *)
+
 
   (** [acquire_state] tracks the acquisition state of a recursive_mutex.
    *)
@@ -500,14 +514,22 @@ cinv (
     cpp.spec "std::recursive_mutex::recursive_mutex()" as ctor_spec' with
       (\this this
       \persist{th} current_thread th
-      \pre{TT P xs} tele_app (TT := TT) P xs
+      \pre{TT P xs} |> tele_app (TT := TT) P xs
       \require ∀ xs, WeaklyObjective (tele_app P xs)
       \post
         Exists g,
-          this |-> R g.(lock_gname) 1 **
+          this |-> R g.(lock_gname) 1$m **
           token g.(lock_gname) 1 **
           used_threads g.(lock_gname) empty **
           inv_rmutex g (∃ xs, tele_app P xs)).
+
+    cpp.spec "std::recursive_mutex::~recursive_mutex()" as dtor_spec' with
+      (\this this
+      \pre{g} this |-> R g.(lock_gname) 1
+      \pre token g.(lock_gname) 1
+      \pre{ths} used_threads g.(lock_gname) ths
+      \pre{TT P} inv_rmutex g (∃ xs, tele_app (TT := TT) P xs)
+      \post |> Exists xs, tele_app (TT := TT) P xs).
 
     cpp.spec "std::recursive_mutex::lock()" as lock_spec' with
       (\this this

--- a/rocq-brick-libstdcpp/proof/mutex/spec/recursive_mutex.v
+++ b/rocq-brick-libstdcpp/proof/mutex/spec/recursive_mutex.v
@@ -616,6 +616,44 @@ cinv (
       ework with br_erefl.
     Qed.
 
+    Lemma dtor_spec_impl_dtor_spec' :
+      dtor_spec |-- dtor_spec'.
+    Proof using MOD HOV HOU.
+      apply specify_mono_fupd; work.
+      iModIntro; work.
+      iExists ths; work.
+      rewrite inv_rmutex.unlock.
+      iInv recursive_mutex.rmutex_namespace as (n th) "[>? ?]" "Hclose".
+      (* TODO: we should cancel this invariant instead *)
+      (* iMod (cinv_cancel with "[$]") as "?". *)
+
+      destruct n as [|n'] eqn:?; work; first last.
+      {
+        (* Somebody else has locked the mutex, but we have the full token.
+        This should be impossible, since we own [token 1], but it's unclear how we'd prove this. *)
+        (* iDestruct (recursive_mutex.locked_excl_same_thread (lock_gname γ) thr 0 (S n) with "[-]") as "[]".
+        work.
+        iDestruct (recursive_mutex.locked_excl_same_thread (lock_gname γ) thr 0 (S n) with "[$]") as "[]".
+        iDestruct "H" as "[[% >?] >?]". *)
+        admit.
+      }
+      iMod ("Hclose" with "[]") as "_". {
+        (* We should _cancel_ the invariant, then we would _not_ need to prove this. *)
+        admit.
+      }
+      iModIntro.
+      ego with br_erefl.
+      wname [inv] "I".
+      wname [own] "L1".
+      wname [own] "L2".
+      iCombine "L1 L2" as "L".
+      (* _now_ we just need to leak ghost state and that's okay *)
+      iApply (affine with "L").
+      apply mpred_BiAffine.
+      Unshelve.
+      all: fail.
+    Admitted.
+
     (* Require Import bluerock.auto.cpp.prelude.proof. *)
     Lemma lock_spec_impl_lock_spec' :
       lock_spec |-- lock_spec'.

--- a/rocq-brick-libstdcpp/test/mutex/guard_recursive.cpp
+++ b/rocq-brick-libstdcpp/test/mutex/guard_recursive.cpp
@@ -1,8 +1,17 @@
 #include <mutex>
 
+void ghost() {}
+
 struct C {
+  /*
+  Original code:
   std::recursive_mutex m;
   int value{0};
+  */
+
+  // This is much easier to verify (avoid strong update for mutex invariant)
+  int value{0};
+  std::recursive_mutex m;
 
   void one_answer() {
     std::unique_lock<std::recursive_mutex> lk(m);
@@ -20,9 +29,21 @@ struct C {
   }
 };
 
+int test_one_answer2(C& c) {
+  std::unique_lock<std::recursive_mutex> lk(c.m);
+
+  c.one_answer();
+
+  return c.value;
+}
+
 int test_one_answer() {
   C c;
+
+  std::unique_lock<std::recursive_mutex> lk(c.m);
+
   c.one_answer();
+
   return c.value;
 }
 

--- a/rocq-brick-libstdcpp/test/mutex/guard_recursive_cpp_proof.v
+++ b/rocq-brick-libstdcpp/test/mutex/guard_recursive_cpp_proof.v
@@ -2,8 +2,69 @@ Require Import skylabs.auto.cpp.prelude.proof.
 Require Import skylabs.brick.libstdcpp.mutex.spec.
 Require Import skylabs.brick.libstdcpp.test.mutex.guard_recursive_cpp.
 
+Import linearity.
+
+Implicit Type (p : ptr) (σ : genv).
+
+Definition TT : tele := [tele (_ : Z)].
+
+#[global] Instance: Inhabited TT.
+Proof. solve_inhabited. Qed.
+
+(** Canonical "constructor" for our telescope. *)
+Polymorphic Definition mk (a : Z) : TT :=
+  {| tele_arg_head := a; tele_arg_tail := () |}.
+Succeed Definition b := recursive_mutex.Held 0 (mk 0).
+
+sl.lock
+Definition CR' `{Σ : cpp_logic, σ : genv} (a : Z) : Rep :=
+  _field "C::value" |-> intR 1$m a.
+#[only(lazy_unfold(export))] derive CR'.
+#[only(timeless)] derive CR'.
+
+(** No *)
+(* A := B *)
+(** Yes *)
+(* A := off |-> B. *)
+
+(* p
+p |->  *)
+
+sl.lock
+Definition P `{Σ : cpp_logic, σ : genv} (this : ptr) : TT -t> mpred :=
+  fun (a : Z) => this |-> CR' a.
+
+sl.lock
+Definition CR
+  `{Σ : cpp_logic, σ : genv} {HAS_THREADS : HasStdThreads Σ}
+  `{!recursive_mutex.lockedG Σ}
+  `{!HasOwn (iPropI _) recursive_mutex.cmraR}
+  (γ : recursive_mutex.rmutex_gname) (q : cQp.t) :=
+  structR "C" q **
+  _field "C::m" |-> recursive_mutex.R γ.(recursive_mutex.lock_gname) q **
+  as_Rep (fun this : ptr =>
+    recursive_mutex.inv_rmutex γ (∃ a : tele_arg TT, tele_app (P this) a)).
+
+#[only(cfractional,ascfractional,cfracvalid,type_ptr)] derive CR.
+#[only(lazy_unfold(export))] derive CR.
+
 Section with_cpp.
   Context `{Σ : cpp_logic, σ : genv} {HAS_THREADS : HasStdThreads Σ}.
+
+  Context `{!recursive_mutex.lockedG Σ}.
+  Context `{!HasOwn (iPropI _) recursive_mutex.cmraR}.
+
+  #[local] Instance: `{WeaklyObjective1 (tele_app (P p))}.
+  Proof. Admitted.
+
+  #[global] Instance P_timeless p a : Timeless (P p a).
+  Proof. rewrite P.unlock; apply _. Qed.
+
+  #[global] Instance P_timeless' p a : Timeless (tele_app (P p) a).
+  Proof. destruct a. apply _. Qed.
+
+  (* int value{0};
+  std::recursive_mutex m; *)
 
   cpp.spec "test_one_answer()" from source with (
     \post[Vint 42] emp
@@ -12,11 +73,110 @@ Section with_cpp.
     \post[Vint 42] emp
   ).
 
-  Lemma test_one_answer_ok :
-    verify?[source] "test_one_answer()".
+  Import recursive_mutex(lock_gname).
+
+  cpp.spec "C::C()" from source as C_ctor_spec with (
+    \this this
+    \persist{thr} current_thread thr
+    \post Exists γ,
+      this |-> CR γ 1$m **
+      recursive_mutex.token (lock_gname γ) 1 **
+      recursive_mutex.used_threads (lock_gname γ) {[thr]} **
+      recursive_mutex.locked (lock_gname γ) thr 0
+  ).
+
+  #[global] Instance unfold (p' : ptr) : `{AutoUnlocking.DefinedUsing (P p n) (p' |-> CR' n')} := {}.
+
+  Lemma C_ctor_ok :
+    verify[source] "C::C()".
+  Proof.
+    verify_shift; go.
+    iExists TT, (P this), (mk 0); go.
+    rewrite {1}P.unlock.
+    go.
+
+    iMod (recursive_mutex.use_thread thr (lock_gname t) ∅ with "[$]") as "?"; first set_solver.
+    iModIntro.
+    rewrite (left_id_L _ (∪)).
+    go.
+  Qed.
+
+  (* Instance: `{ShouldInlineFunction n} | 1000 := {}. *)
+  cpp.spec "C::one_answer()" from source inline.
+
+  (* cpp.spec "C::~C()" from source inline. *)
+  cpp.spec "C::~C()" from source as C_dtor_spec with (
+    \this this
+    \persist{thr} current_thread thr
+    \pre{γ} this |-> CR γ 1$m
+    \pre recursive_mutex.token (lock_gname γ) 1
+    \pre{thrs} recursive_mutex.used_threads (lock_gname γ) thrs
+    (* Currently unused, but callers are likely to have this and need to leak it. *)
+    \pre recursive_mutex.locked (lock_gname γ) thr 0
+
+    (* **
+      token (lock_gname γ) 1 **
+      used_threads (lock_gname γ) {[thr]} **
+      locked (lock_gname γ) thr 0 *)
+    \post emp).
+
+
+  Lemma C_dtor_ok :
+    (* We only get [|> recursive_mutex.dtor_spec'], and that's not enough *)
+    recursive_mutex.dtor_spec' |--
+    verify[source] "C::~C()".
   Proof.
     verify_spec; go.
-  Admitted.
+    iExists thrs; go.
+    destruct t as [? []]; rewrite P.unlock; go.
+
+    (* _now_ we just need to leak ghost state and that's okay *)
+    wname [recursive_mutex.locked] "L".
+    iApply (affine with "L").
+    apply mpred_BiAffine.
+  Qed.
+
+  cpp.spec "ghost()" from source as ghost_spec with (
+    \pre{P}
+     |={⊤}=>
+    P
+    \post P).
+
+  Lemma test_one_answer_ok :
+    verify[source] "test_one_answer()".
+  Proof.
+    verify_spec; go.
+    wname [recursive_mutex.locked (lock_gname t) thr 0] "C".
+    iAssert (recursive_mutex.acquireable (TT := TT) t thr recursive_mutex.NotHeld (P c_addr)) with "[C]" as "?". {
+      by rewrite recursive_mutex.acquireable.unlock; iFrame.
+    }
+    go.
+    rewrite P.unlock.
+    destruct args as [a []]; simpl in *.
+    go.
+
+    iExists ?[K], (mk 42).
+    go.
+    iSplitL ""; go.
+    Unset SsrIdents.
+    rename _n_ into n0.
+    Set SsrIdents.
+    (* This step breaks abstractions, but we have taken the lock yet hints don't
+    give us access to the resouce. *)
+    assert (n0 = 0 /\ n = 1)%nat as [-> ->]. {
+      rewrite-> recursive_mutex.release.unlock in *.
+      destruct n0, n; naive_solver.
+    }
+    rewrite recursive_mutex.release.unlock /=.
+    go.
+    iExists ?[K], (mk 42); go.
+    iSplitL ""; go.
+    ego with br_erefl.
+    rewrite P.unlock CR'.unlock.
+    rewrite recursive_mutex.release.unlock /=.
+    rewrite recursive_mutex.acquireable.unlock /=.
+    go.
+  Qed.
 
   Lemma test_other_answer_ok :
     verify?[source] "test_other_answer()".

--- a/rocq-brick-libstdcpp/test/mutex/guard_recursive_cpp_proof.v
+++ b/rocq-brick-libstdcpp/test/mutex/guard_recursive_cpp_proof.v
@@ -157,26 +157,45 @@ Section with_cpp.
 
     iExists ?[K], (mk 42).
     go.
-    iSplitL ""; go.
-    Unset SsrIdents.
-    rename _n_ into n0.
-    Set SsrIdents.
-    (* This step breaks abstractions, but we have taken the lock yet hints don't
-    give us access to the resouce. *)
-    assert (n0 = 0 /\ n = 1)%nat as [-> ->]. {
-      rewrite-> recursive_mutex.release.unlock in *.
-      destruct n0, n; naive_solver.
-    }
-    rewrite recursive_mutex.release.unlock /=.
+    iSplitL ""; first by go.
     go.
-    iExists ?[K], (mk 42); go.
+    have [? [??]] : exists a, n = 1%nat /\ recursive_mutex.acquire a (recursive_mutex.release (recursive_mutex.Held n (mk 42))). {
+      Unset SsrIdents.
+      rename _n_ into n0.
+      Set SsrIdents.
+      (* This step breaks abstractions, but we have taken the lock yet hints don't
+      give us access to the resouce. *)
+      assert (n0 = 0 /\ n = 1)%nat as [-> ->]. {
+        rewrite-> recursive_mutex.release.unlock in *.
+        destruct n0, n; naive_solver.
+      }
+      rewrite recursive_mutex.release.unlock /=.
+      exists recursive_mutex.NotHeld.
+      split; first done.
+      typeclasses eauto with br_hints.
+    }
+    rewrite CR'.unlock.
+    go.
+    destruct args as [a1 []]; go.
+    iExists ?[K], (mk a1); go.
     iSplitL ""; go.
     ego with br_erefl.
-    rewrite P.unlock CR'.unlock.
-    rewrite recursive_mutex.release.unlock /=.
+    rewrite P.unlock CR'.unlock; go.
+    rewrite (_ : recursive_mutex.release (recursive_mutex.Held n (mk a1)) = recursive_mutex.NotHeld).
+    Fail progress go.
     rewrite recursive_mutex.acquireable.unlock /=.
     go.
+
+    wfocus [| _ |] ""; last by go. {
+      iPureIntro.
+      rewrite-> recursive_mutex.release.unlock in *.
+      case_match; naive_solver.
+    }
+    rewrite-> recursive_mutex.release.unlock in *; naive_solver.
   Qed.
+  (* TODO: when we project out equalities about Held and NotHeld, project info
+  about the holding counts; that cancels out better when we repeatedly lock and
+  unlock things. *)
 
   Lemma test_other_answer_ok :
     verify?[source] "test_other_answer()".


### PR DESCRIPTION
cc @gmalecha-at-skylabs @mansky1 .

Issues:
- automation is terrible when repeatedly locking and unlocking a mutex. I have an idea I'd like to try — we could expose equalities on the lock counts inside `acquire_state`.

- we don't get back ownership when destructing a recursive mutex. There are TODOs, but this is trickier.
