### PR TITLE
Specs of addressof

### DIFF
--- a/rocq-brick-libstdcpp/proof/dune.inc
+++ b/rocq-brick-libstdcpp/proof/dune.inc
@@ -83,6 +83,18 @@
   	 (with-stderr-to inc_iostream_cpp.v.stderr (run cpp2v -v %{input} -o inc_iostream_cpp.v --no-elaborate --templates=inc_iostream_cpp_templates.v  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps inc_iostream.cpp))
 )
+(subdir memory
+ (rule
+  (targets inc_hpp.v.stderr inc_hpp.v inc_hpp_templates.v)
+  (alias test_ast)
+  (deps
+   (:input inc.hpp)
+   (env_var CPP2V_DOCKER_ENABLED)
+   (glob_files_rec ../*.hpp))
+  (action
+  	 (with-stderr-to inc_hpp.v.stderr (run cpp2v -v %{input} -o inc_hpp.v --no-elaborate --templates=inc_hpp_templates.v  -- -std=c++20 -stdlib=libstdc++ ))))
+ (alias (name srcs) (deps inc.hpp))
+)
 (subdir mutex
  (rule
   (targets demo_cpp.v.stderr demo_cpp.v demo_cpp_templates.v)

--- a/rocq-brick-libstdcpp/proof/memory/inc.hpp
+++ b/rocq-brick-libstdcpp/proof/memory/inc.hpp
@@ -1,0 +1,1 @@
+#include <memory>

--- a/rocq-brick-libstdcpp/proof/memory/spec/addressof.v
+++ b/rocq-brick-libstdcpp/proof/memory/spec/addressof.v
@@ -1,0 +1,27 @@
+Require Import skylabs.auto.cpp.spec.
+
+Require Import skylabs.brick.libstdcpp.memory.inc_hpp.
+Require Import skylabs.brick.libstdcpp.memory.inc_hpp_templates.
+
+NES.Begin memory.
+  Section with_cpp.
+    Context `{Σ : cpp_logic, σ : genv}.
+
+    Section with_ty.
+      Context (ty : type).
+
+      cpp.spec "std::__addressof<$ty>($ty&)" as __addressof_spec from inc_hpp.source templates inc_hpp_templates.templates (
+        \\with
+        \arg{mp} "" (Vref mp)
+        \post[Vptr mp] emp
+      ).
+
+      cpp.spec "std::addressof<$ty>($ty&)" as addressof_spec from inc_hpp.source templates inc_hpp_templates.templates (
+        \\with
+        \arg{mp} "" (Vref mp)
+        \post[Vptr mp] emp
+      ).
+
+    End with_ty.
+  End with_cpp.
+NES.End memory.

--- a/rocq-brick-libstdcpp/test/dune.inc
+++ b/rocq-brick-libstdcpp/test/dune.inc
@@ -203,6 +203,18 @@
   	 (with-stderr-to N6_print_sizeof_cpp.v.stderr (run cpp2v -v %{input} -o N6_print_sizeof_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps N6_print_sizeof.cpp))
 )
+(subdir memory
+ (rule
+  (targets test_cpp.v.stderr test_cpp.v)
+  (alias test_ast)
+  (deps
+   (:input test.cpp)
+   (env_var CPP2V_DOCKER_ENABLED)
+   (glob_files_rec ../*.hpp))
+  (action
+  	 (with-stderr-to test_cpp.v.stderr (run cpp2v -v %{input} -o test_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
+ (alias (name srcs) (deps test.cpp))
+)
 (subdir mutex
  (rule
   (targets guard_recursive_cpp.v.stderr guard_recursive_cpp.v)

--- a/rocq-brick-libstdcpp/test/memory/test.cpp
+++ b/rocq-brick-libstdcpp/test/memory/test.cpp
@@ -1,0 +1,4 @@
+#include <memory>
+
+struct C{};
+template C* std::addressof<C>(C&);

--- a/rocq-brick-libstdcpp/test/memory/test_cpp_proof.v
+++ b/rocq-brick-libstdcpp/test/memory/test_cpp_proof.v
@@ -1,0 +1,25 @@
+Require Import skylabs.auto.cpp.prelude.proof.
+
+Require Import skylabs.brick.libstdcpp.memory.spec.addressof.
+Require Import skylabs.brick.libstdcpp.lib.tactics.
+Require Import skylabs.brick.libstdcpp.test.memory.test_cpp.
+
+NES.Begin memory.
+  Section with_cpp.
+    Context `{Σ : cpp_logic, σ : genv}.
+
+    Lemma addressof_ok : __addressof_spec "C" source |-- verify?[source] "std::addressof<C>(C&)".
+    Proof.
+      work; iStopProof; untemplate_goal.
+
+      verify_spec; go.
+    Qed.
+
+    Lemma __addressof_ok : verify?[source] "std::__addressof<C>(C&)".
+    Proof.
+      work; iStopProof; untemplate_goal.
+
+      verify_spec; go.
+    Abort.
+  End with_cpp.
+NES.End memory.


### PR DESCRIPTION
Also prove `addressof` correct over `__addressof` (for a test instance, to move). Proving `__addressof` correct will need a new axiom for the builtin.

Fix https://github.com/SkyLabsAI/brick-libcpp/issues/62.