### PR TITLE
Support spaceship operator, library specs

### DIFF
--- a/rocq-brick-libstdcpp/proof/compare/hints.v
+++ b/rocq-brick-libstdcpp/proof/compare/hints.v
@@ -1,0 +1,182 @@
+(*
+ * Copyright (c) 2026 SkyLabs AI, Inc.
+ * This software is distributed under the terms of the BedRock Open-Source License.
+ * See the LICENSE-BedRock file in the repository root for details.
+ *)
+Require Import skylabs.auto.cpp.prelude.proof.
+Require Export skylabs.brick.libstdcpp.compare.spec.
+Require Import skylabs.brick.libstdcpp.compare.inc_compare_cpp.
+
+Import linearity.
+
+(* TODO upstream! *)
+#[only(finite)] derive comparison.
+
+(* TODO upstream? *)
+#[local] Arguments qual_norm {_} _ !_ /.
+#[local] Typeclasses Opaque int_rank.t_leb.
+#[local] Typeclasses Opaque int_rank.t_le.
+
+Section with_cpp.
+  Context `{Σ : cpp_logic, σ : genv}.
+
+  (* TODO upstream? *)
+  Section fixed_var_hint.
+    Context (tu : translation_unit) (ρ : region).
+
+    Abbreviation interp := (interp tu).
+    Abbreviation wp_prval := (wp_prval tu ρ).
+    Abbreviation wp_operand := (wp_operand tu ρ).
+    Abbreviation wp_lval := (wp_lval tu ρ).
+    Abbreviation wp_xval := (wp_xval tu ρ).
+    Abbreviation wp_glval := (wp_glval tu ρ).
+    Abbreviation wp_init := (wp_init tu ρ).
+    Abbreviation wp_initialize := (wp_initialize tu ρ).
+    Abbreviation wp_discard := (wp_discard tu ρ).
+    Abbreviation wp := (wp tu ρ).
+    Abbreviation wp_decl := (wp_decl tu ρ).
+
+    #[local] Open Scope free_scope.
+
+    Lemma wp_lval_global Q nm ty :
+      wp.check_global tu nm ty =[Vm]=> true ->
+          Q (_global nm) FreeTemps.id
+      |-- wp_lval (Eglobal nm ty) Q.
+    Proof.
+      rewrite RedEq_eq_iff => H.
+      apply @wp.wp_lval_global.
+      by rewrite RedEq_eq_iff H.
+    Qed.
+    Definition wp_lval_global_B := [BWD] wp_lval_global.
+  End fixed_var_hint.
+
+  #[local] Remove Hints wp.wp_lval_global_B : db_skylabs_wp.
+  #[local] Hint Resolve wp_lval_global_B | 150 : db_skylabs_wp.
+
+  Section with_resolve.
+    Variables (tu : translation_unit) (ρ : region).
+
+    #[local] Abbreviation wp_init := (wp_init tu ρ).
+    #[local] Abbreviation wp_operand := (wp_operand tu ρ).
+    #[local] Open Scope free_scope.
+
+    Lemma wp_operand_frame' e :
+      ⊢ wp.WPE.Mframe (wp_operand e) (wp_operand e).
+    Proof.
+      rewrite /wp.WPE.Mframe.
+      iIntros "* W".
+      by iApply wp_operand_frame.
+    Qed.
+
+    Definition strong_ordering_result_names : list PrimString.string :=
+      Eval compute in (strong_ordering_result_name <$> enum _).
+    Succeed Example foo :
+      strong_ordering_result_names = ["equal"; "less"; "greater"]%pstring := eq_refl.
+
+    Definition partial_ordering_result_names : list PrimString.string :=
+      Eval compute in (partial_ordering_result_name <$> enum _).
+    Succeed Example foo :
+      partial_ordering_result_names =
+      ["unordered" ; "equivalent" ; "less" ; "greater"]%pstring := eq_refl.
+
+    Definition cmp_expected_cls (te1 : type) : option name :=
+      match te1 with
+      | Tnum sz sgn =>
+        (* from arith_as *)
+        if bool_decide (int_rank.t_le int_rank.Iint sz) then
+          Some "std::strong_ordering"%cpp_name
+        else
+          None
+      | Tfloat_ fty =>
+          Some "std::partial_ordering"%cpp_name
+      | _ => None
+      end.
+
+    Definition cmp_res (te1 : type) (v1 v2 : val) (p : ptr) (Q : mpred) : mpred :=
+      ∃ q,
+      match te1, v1, v2 with
+      | Tnum sz sgn, Vint a, Vint b =>
+        (* from arith_as *)
+        if bool_decide (int_rank.t_le int_rank.Iint sz) then
+          let cmp_res := Z.compare a b in
+          std.compare.strong_ordering_copy_ctor **
+          std.compare.strong_ordering_globals q **
+          (std.compare.strong_ordering_globals q **
+          p |-> std.compare.strong_orderingR 1$m cmp_res -*
+          Q)
+        else
+          False%I
+      | Tfloat_ fty, Vfloat f a, Vfloat f' b =>
+        match decide (f = fty), decide (f' = fty) with
+        | left H, left H' =>
+          let a' := eq_rect f float_type.car a fty H in
+          let b' := eq_rect f' float_type.car b fty H' in
+          let cmp_res := float_value.value_compare a' b' in
+          std.compare.partial_ordering_copy_ctor **
+          std.compare.partial_ordering_globals q **
+          (std.compare.partial_ordering_globals q **
+          p |-> std.compare.partial_orderingR 1$m cmp_res -*
+          Q)
+        | _, _ => False
+        end
+      | _, _, _ => False
+      end.
+    #[global] Hint Opaque cmp_res : sl_opacity.
+    #[global] Arguments cmp_res !_ /.
+
+    (* Ensure the [wp_init_binop_spaceship] desugaring is valid here.
+    The [Econstructor] typechecker is currently trivial, but this will be fixed. *)
+    Definition wp_init_binop_spaceship_stdlib_hint_typecheck ty te1 cls :=
+      let ctor := cls .:: Nctor [Tref $ Tconst $ Tnamed cls] in
+      let res_to_type := fun res_name =>
+        let arg := Eglobal (cls .:: Nid res_name) (Tconst (Tnamed cls)) in
+        decltype.of_expr (Econstructor ctor [arg] ty) in
+      let args : list PrimString.string :=
+        match te1 with
+        | Tnum _ _ => strong_ordering_result_names
+        | Tfloat_ _ => partial_ordering_result_names
+        | _ => []
+        end in
+      bool_decide (res_to_type <$> args = const (Some ty) <$> args).
+
+    Lemma wp_init_binop_spaceship_stdlib_hint e1 e2 ty te1 (addr : ptr) cls Q :
+      (drop_qualifiers (type_of e1), drop_qualifiers (type_of e2), snd (decompose_type ty)) =[Vm]=> (te1, te1, Tnamed cls) ->
+      (Tnamed <$> cmp_expected_cls te1) =[Vm]=> Some ty ->
+      wp_init_binop_spaceship_stdlib_hint_typecheck ty te1 cls =[Vm]=> true ->
+      (letI* '(v1, v2), free := eval2 (evaluation_order.order_of (language_version tu) OOSpaceship)
+        (wp_operand e1) (wp_operand e2) in
+      cmp_res te1 v1 v2 addr
+        (* XXX [(1 >*> 1) >*>] is unfortunate temporary noise *)
+        (Q ((1 >*> 1) >*> free)))
+    |-- wp_init ty addr (Ebinop Bcmp e1 e2 ty) Q.
+    Proof.
+      rewrite /cmp_expected_cls !RedEq_eq_iff; intros ?? Htype.
+      clear Htype. (* actual typechecking's trivial. *)
+      rewrite -wp_init_binop_spaceship /=; last congruence.
+      destruct (decompose_type ty) eqn:?; simplify_eq/=.
+      iApply (nd_seq_frame with "[][] []"); [iApply wp_operand_frame'..|].
+      iIntros ([v1 v2] ?) "[% W]".
+      destruct cmp_res_name eqn:C;
+        rewrite /cmp_res /cmp_res_name in C |- *.
+      2: repeat (case_match; simplify_eq/=; try iDestruct "W" as "[]").
+      iDestruct "W" as "?"; work.
+
+      repeat (case_match; try by exfalso); simplify_eq/=.
+      all: go.
+      (* ^^ applies invoke.wp_init_ctor_C *)
+      all: rewrite -E.wp_lval_global /= /read_decl /=.
+      all: rewrite /strong_ordering_result_name /partial_ordering_result_name.
+      all: (iSplitR; first by (repeat case_match; work)).
+      all: work.
+      all: iExists q; [> iExists (z ?= z0) | iExists (float_value.value_compare c c0) ].
+      all: repeat case_match.
+      all: work.
+    Qed.
+    Definition wp_init_binop_spaceship_stdlib_hint_B :=
+      [BWD] wp_init_binop_spaceship_stdlib_hint.
+
+  End with_resolve.
+End with_cpp.
+
+#[export] Hint Resolve wp_init_binop_spaceship_stdlib_hint_B | 150 : db_skylabs_wp.
+

--- a/rocq-brick-libstdcpp/proof/compare/inc_compare.cpp
+++ b/rocq-brick-libstdcpp/proof/compare/inc_compare.cpp
@@ -1,0 +1,1 @@
+#include <compare>

--- a/rocq-brick-libstdcpp/proof/compare/pred.v
+++ b/rocq-brick-libstdcpp/proof/compare/pred.v
@@ -1,0 +1,83 @@
+(*
+ * Copyright (c) 2026 SkyLabs AI, Inc.
+ * This software is distributed under the terms of the BedRock Open-Source License.
+ * See the LICENSE-BedRock file in the repository root for details.
+ *)
+Require Import skylabs.auto.cpp.prelude.spec.
+Require Import skylabs.auto.cpp.proof.
+
+#[local] Open Scope Z_scope.
+
+NES.Begin std.compare.
+
+  Definition ordering_value (v : comparison) : Z :=
+    match v with
+    | Lt => -1
+    | Eq => 0
+    | Gt => 1
+    end.
+
+  Definition partial_ordering_value (v : option comparison) : Z :=
+    match v with
+    | Some v => ordering_value v
+    | None => 2
+    end.
+
+  sl.lock
+  Definition strong_orderingR `{Σ : cpp_logic, σ : genv}
+      (q : cQp.t) (v : comparison) : Rep :=
+    structR "std::strong_ordering" q **
+    _field "std::strong_ordering::_M_value" |-> primR Tschar q (Vint (ordering_value v)).
+  #[only(cfractional,cfracvalid,ascfractional,timeless,type_ptr,lazy_unfold(global))] derive strong_orderingR.
+  Definition _at_strong_orderingR_learn `{Σ : cpp_logic, σ : genv} :
+    AtLearnEqF1 strong_orderingR := ltac:(solve_learnable).
+  #[global] Hint Resolve _at_strong_orderingR_learn : sl_opacity.
+
+
+  sl.lock
+  Definition partial_orderingR `{Σ : cpp_logic, σ : genv}
+      (q : cQp.t) (v : option comparison) : Rep :=
+    structR "std::partial_ordering" q **
+    _field "std::partial_ordering::_M_value" |-> primR Tschar q (Vint (partial_ordering_value v)).
+  #[only(cfractional,cfracvalid,ascfractional,timeless,type_ptr,lazy_unfold(global))] derive partial_orderingR.
+  Definition _at_partial_orderingR_learn `{Σ : cpp_logic, σ : genv} :
+    AtLearnEqF1 partial_orderingR := ltac:(solve_learnable).
+  #[global] Hint Resolve _at_partial_orderingR_learn : sl_opacity.
+
+  sl.lock
+  Definition weak_orderingR `{Σ : cpp_logic, σ : genv}
+      (q : cQp.t) (v : comparison) : Rep :=
+    structR "std::weak_ordering" q **
+    _field "std::weak_ordering::_M_value" |-> primR Tschar q (Vint (ordering_value v)).
+  #[only(cfractional,cfracvalid,ascfractional,timeless,type_ptr,lazy_unfold(global))] derive weak_orderingR.
+  Definition _at_weak_orderingR_learn `{Σ : cpp_logic, σ : genv} :
+    AtLearnEqF1 weak_orderingR := ltac:(solve_learnable).
+  #[global] Hint Resolve _at_weak_orderingR_learn : sl_opacity.
+
+  sl.lock
+  Definition unspecR `{Σ : cpp_logic, σ : genv} (q : cQp.t) : Rep :=
+    structR "std::__cmp_cat::__unspec" q ** emp.
+  #[only(cfractional,cfracvalid,ascfractional,timeless,type_ptr,lazy_unfold(global))] derive unspecR.
+
+  #[global] Abbreviation strong_ordering_globals q := (
+    _global "std::strong_ordering::less" |-> strong_orderingR q Lt **
+    _global "std::strong_ordering::equal" |-> strong_orderingR q Eq **
+    _global "std::strong_ordering::greater" |-> strong_orderingR q Gt).
+
+  #[global] Abbreviation weak_ordering_globals q := (
+    _global "std::weak_ordering::less" |-> weak_orderingR q Lt **
+    _global "std::weak_ordering::equivalent" |-> weak_orderingR q Eq **
+    _global "std::weak_ordering::greater" |-> weak_orderingR q Gt).
+
+  #[global] Abbreviation partial_ordering_globals q := (
+    _global "std::partial_ordering::less" |-> partial_orderingR q (Some Lt) **
+    _global "std::partial_ordering::equivalent" |-> partial_orderingR q (Some Eq) **
+    _global "std::partial_ordering::greater" |-> partial_orderingR q (Some Gt) **
+    _global "std::partial_ordering::unordered" |-> partial_orderingR q None).
+
+  #[global] Abbreviation compare_globals q := (
+    strong_ordering_globals q **
+    weak_ordering_globals q **
+    partial_ordering_globals q).
+
+NES.End std.compare.

--- a/rocq-brick-libstdcpp/proof/compare/spec.v
+++ b/rocq-brick-libstdcpp/proof/compare/spec.v
@@ -1,0 +1,280 @@
+(*
+ * Copyright (c) 2026 SkyLabs AI, Inc.
+ * This software is distributed under the terms of the BedRock Open-Source License.
+ * See the LICENSE-BedRock file in the repository root for details.
+ *)
+Require Import skylabs.auto.cpp.prelude.spec.
+Require Export skylabs.brick.libstdcpp.compare.pred.
+Require Import skylabs.brick.libstdcpp.compare.inc_compare_cpp.
+
+#[local] Open Scope Z_scope.
+
+NES.Begin std.compare.
+
+Section with_cpp.
+  Context `{Σ : cpp_logic, source ⊧ σ}.
+
+  cpp.spec "std::strong_ordering::strong_ordering(const std::strong_ordering&)" as strong_ordering_copy_ctor from source with (
+    \this this
+    \arg{other} "" (Vptr other)
+    \prepost{q v} other |-> strong_orderingR q v
+    \post this |-> strong_orderingR 1$m v).
+
+  cpp.spec "std::strong_ordering::strong_ordering(std::strong_ordering&&)" as strong_ordering_move_ctor from source with (
+    \this this
+    \arg{other} "" (Vptr other)
+    \prepost{q v} other |-> strong_orderingR q v
+    \post this |-> strong_orderingR 1$m v).
+
+  cpp.spec "std::strong_ordering::~strong_ordering()" as strong_ordering_dtor from source with (
+    \this this
+    \pre{v} this |-> strong_orderingR 1$m v
+    \post emp).
+
+  cpp.spec "std::partial_ordering::~partial_ordering()" as partial_ordering_dtor from source with (
+    \this this
+    \pre{v} this |-> partial_orderingR 1$m v
+    \post emp).
+
+  cpp.spec "std::partial_ordering::partial_ordering(const std::partial_ordering&)" as partial_ordering_copy_ctor from source with (
+    \this this
+    \arg{other} "" (Vptr other)
+    \prepost{q v} other |-> partial_orderingR q v
+    \post this |-> partial_orderingR 1$m v).
+
+  cpp.spec "std::partial_ordering::partial_ordering(std::partial_ordering&&)" as partial_ordering_move_ctor from source with (
+    \this this
+    \arg{other} "" (Vptr other)
+    \prepost{q v} other |-> partial_orderingR q v
+    \post this |-> partial_orderingR 1$m v).
+
+  cpp.spec "std::weak_ordering::weak_ordering(const std::weak_ordering&)" as weak_ordering_copy_ctor from source with (
+    \this this
+    \arg{other} "" (Vptr other)
+    \prepost{q v} other |-> weak_orderingR q v
+    \post this |-> weak_orderingR 1$m v).
+
+  cpp.spec "std::weak_ordering::weak_ordering(std::weak_ordering&&)" as weak_ordering_move_ctor from source with (
+    \this this
+    \arg{other} "" (Vptr other)
+    \prepost{q v} other |-> weak_orderingR q v
+    \post this |-> weak_orderingR 1$m v).
+
+  cpp.spec "std::weak_ordering::~weak_ordering()" as weak_ordering_dtor from source with (
+    \this this
+    \pre{v} this |-> weak_orderingR 1$m v
+    \post emp).
+
+  cpp.spec "std::operator==(std::strong_ordering, std::strong_ordering)" as strong_ordering_eq from source with (
+    \arg{lhs} "" (Vptr lhs)
+    \arg{rhs} "" (Vptr rhs)
+    \prepost{q_lhs lhs_v} lhs |-> strong_orderingR q_lhs lhs_v
+    \prepost{q_rhs rhs_v} rhs |-> strong_orderingR q_rhs rhs_v
+    \post[Vbool (bool_decide (lhs_v = rhs_v))] emp).
+
+  cpp.spec "std::operator==(std::partial_ordering, std::partial_ordering)" as partial_ordering_eq from source with (
+    \arg{lhs} "" (Vptr lhs)
+    \arg{rhs} "" (Vptr rhs)
+    \prepost{q_lhs lhs_v} lhs |-> partial_orderingR q_lhs lhs_v
+    \prepost{q_rhs rhs_v} rhs |-> partial_orderingR q_rhs rhs_v
+    \post[Vbool (bool_decide (lhs_v = rhs_v))] emp).
+
+  cpp.spec "std::operator==(std::weak_ordering, std::weak_ordering)" as weak_ordering_eq from source with (
+    \arg{lhs} "" (Vptr lhs)
+    \arg{rhs} "" (Vptr rhs)
+    \prepost{q_lhs lhs_v} lhs |-> weak_orderingR q_lhs lhs_v
+    \prepost{q_rhs rhs_v} rhs |-> weak_orderingR q_rhs rhs_v
+    \post[Vbool (bool_decide (lhs_v = rhs_v))] emp).
+
+  cpp.spec "std::strong_ordering::operator std::partial_ordering() const"
+      as strong_to_partial from source with (
+      \this this
+      \prepost{q v} this |-> strong_orderingR q v
+      \post{result}[Vptr result] result |-> partial_orderingR 1$m (Some v)).
+
+  cpp.spec "std::weak_ordering::operator std::partial_ordering() const"
+      as weak_to_partial from source with (
+      \this this
+      \prepost{q v} this |-> weak_orderingR q v
+      \post{result}[Vptr result] result |-> partial_orderingR 1$m (Some v)).
+
+  cpp.spec "std::__cmp_cat::__unspec::__unspec(std::__cmp_cat::__unspec*)" as unspec_ctor from source with (
+    \this this
+    \arg{p} "" (Vptr p)
+    \pre [| p = nullptr |]
+    \post this |-> unspecR 1$m).
+
+  cpp.spec "std::__cmp_cat::__unspec::~__unspec()" as unspec_dtor from source with (
+    \this this
+    \pre this |-> unspecR 1$m
+    \post emp).
+
+  cpp.spec "std::operator==(std::partial_ordering, std::__cmp_cat::__unspec)" as partial_ordering_eq_unspec from source with (
+    \arg{lhs} "" (Vptr lhs)
+    \arg{rhs} "" (Vptr rhs)
+    \prepost{q_lhs lhs_v} lhs |-> partial_orderingR q_lhs lhs_v
+    \pre{q_rhs} rhs |-> unspecR q_rhs
+    \post[Vbool (bool_decide (lhs_v = Some Eq))] rhs |-> unspecR q_rhs).
+
+  cpp.spec "std::operator<(std::partial_ordering, std::__cmp_cat::__unspec)" as partial_ordering_lt_unspec from source with (
+    \arg{lhs} "" (Vptr lhs)
+    \arg{rhs} "" (Vptr rhs)
+    \prepost{q_lhs lhs_v} lhs |-> partial_orderingR q_lhs lhs_v
+    \pre{q_rhs} rhs |-> unspecR q_rhs
+    \post[Vbool (bool_decide (lhs_v = Some Lt))] rhs |-> unspecR q_rhs).
+
+  cpp.spec "std::operator>(std::partial_ordering, std::__cmp_cat::__unspec)" as partial_ordering_gt_unspec from source with (
+    \arg{lhs} "" (Vptr lhs)
+    \arg{rhs} "" (Vptr rhs)
+    \prepost{q_lhs lhs_v} lhs |-> partial_orderingR q_lhs lhs_v
+    \pre{q_rhs} rhs |-> unspecR q_rhs
+    \post[Vbool (bool_decide (lhs_v = Some Gt))] rhs |-> unspecR q_rhs).
+
+  cpp.spec "std::operator<=>(std::partial_ordering, std::__cmp_cat::__unspec)" as partial_ordering_cmp_unspec from source with (
+    \arg{lhs} "" (Vptr lhs)
+    \arg{rhs} "" (Vptr rhs)
+    \prepost{q_lhs lhs_v} lhs |-> partial_orderingR q_lhs lhs_v
+    \pre{q_rhs} rhs |-> unspecR q_rhs
+    \post{result}[Vptr result] result |-> partial_orderingR 1$m lhs_v ** rhs |-> unspecR q_rhs).
+
+  cpp.spec "std::operator<(std::strong_ordering, std::__cmp_cat::__unspec)" as strong_ordering_lt_unspec from source with (
+    \arg{lhs} "" (Vptr lhs)
+    \arg{rhs} "" (Vptr rhs)
+    \prepost{q_lhs lhs_v} lhs |-> strong_orderingR q_lhs lhs_v
+    \pre{q_rhs} rhs |-> unspecR q_rhs
+    \post[Vbool (bool_decide (lhs_v = Lt))] rhs |-> unspecR q_rhs).
+
+  cpp.spec "std::operator==(std::strong_ordering, std::__cmp_cat::__unspec)" as strong_ordering_eq_unspec from source with (
+    \arg{lhs} "" (Vptr lhs)
+    \arg{rhs} "" (Vptr rhs)
+    \prepost{q_lhs lhs_v} lhs |-> strong_orderingR q_lhs lhs_v
+    \pre{q_rhs} rhs |-> unspecR q_rhs
+    \post[Vbool (bool_decide (lhs_v = Eq))] rhs |-> unspecR q_rhs).
+
+  cpp.spec "std::operator>(std::strong_ordering, std::__cmp_cat::__unspec)" as strong_ordering_gt_unspec from source with (
+    \arg{lhs} "" (Vptr lhs)
+    \arg{rhs} "" (Vptr rhs)
+    \prepost{q_lhs lhs_v} lhs |-> strong_orderingR q_lhs lhs_v
+    \pre{q_rhs} rhs |-> unspecR q_rhs
+    \post[Vbool (bool_decide (lhs_v = Gt))] rhs |-> unspecR q_rhs).
+
+  cpp.spec "std::operator<=>(std::strong_ordering, std::__cmp_cat::__unspec)" as strong_ordering_cmp_unspec from source with (
+    \arg{lhs} "" (Vptr lhs)
+    \arg{rhs} "" (Vptr rhs)
+    \prepost{q_lhs lhs_v} lhs |-> strong_orderingR q_lhs lhs_v
+    \pre{q_rhs} rhs |-> unspecR q_rhs
+    \post{result}[Vptr result] result |-> strong_orderingR 1$m lhs_v ** rhs |-> unspecR q_rhs).
+
+  cpp.spec "std::operator==(std::weak_ordering, std::__cmp_cat::__unspec)" as weak_ordering_eq_unspec from source with (
+    \arg{lhs} "" (Vptr lhs)
+    \arg{rhs} "" (Vptr rhs)
+    \prepost{q_lhs lhs_v} lhs |-> weak_orderingR q_lhs lhs_v
+    \pre{q_rhs} rhs |-> unspecR q_rhs
+    \post[Vbool (bool_decide (lhs_v = Eq))] rhs |-> unspecR q_rhs).
+
+  cpp.spec "std::operator>(std::weak_ordering, std::__cmp_cat::__unspec)" as weak_ordering_gt_unspec from source with (
+    \arg{lhs} "" (Vptr lhs)
+    \arg{rhs} "" (Vptr rhs)
+    \prepost{q_lhs lhs_v} lhs |-> weak_orderingR q_lhs lhs_v
+    \pre{q_rhs} rhs |-> unspecR q_rhs
+    \post[Vbool (bool_decide (lhs_v = Gt))] rhs |-> unspecR q_rhs).
+
+  cpp.spec "std::operator<=>(std::weak_ordering, std::__cmp_cat::__unspec)" as weak_ordering_cmp_unspec from source with (
+    \arg{lhs} "" (Vptr lhs)
+    \arg{rhs} "" (Vptr rhs)
+    \prepost{q_lhs lhs_v} lhs |-> weak_orderingR q_lhs lhs_v
+    \pre{q_rhs} rhs |-> unspecR q_rhs
+    \post{result}[Vptr result] result |-> weak_orderingR 1$m lhs_v ** rhs |-> unspecR q_rhs).
+
+  cpp.spec "std::operator<(std::__cmp_cat::__unspec, std::partial_ordering)" as unspec_lt_partial_ordering from source with (
+    \arg{lhs} "" (Vptr lhs)
+    \arg{rhs} "" (Vptr rhs)
+    \pre{q_lhs} lhs |-> unspecR q_lhs
+    \prepost{q_rhs rhs_v} rhs |-> partial_orderingR q_rhs rhs_v
+    \post[Vbool (bool_decide (rhs_v = Some Gt))] lhs |-> unspecR q_lhs).
+
+  cpp.spec "std::operator<=>(std::__cmp_cat::__unspec, std::partial_ordering)" as unspec_cmp_partial_ordering from source with (
+    \arg{lhs} "" (Vptr lhs)
+    \arg{rhs} "" (Vptr rhs)
+    \pre{q_lhs} lhs |-> unspecR q_lhs
+    \prepost{q_rhs rhs_v} rhs |-> partial_orderingR q_rhs rhs_v
+    \post{result}[Vptr result] result |-> partial_orderingR 1$m (CompOpp <$> rhs_v) ** lhs |-> unspecR q_lhs).
+
+  cpp.spec "std::operator>(std::__cmp_cat::__unspec, std::strong_ordering)" as unspec_gt_strong_ordering from source with (
+    \arg{lhs} "" (Vptr lhs)
+    \arg{rhs} "" (Vptr rhs)
+    \pre{q_lhs} lhs |-> unspecR q_lhs
+    \prepost{q_rhs rhs_v} rhs |-> strong_orderingR q_rhs rhs_v
+    \post[Vbool (bool_decide (rhs_v = Lt))] lhs |-> unspecR q_lhs).
+
+  cpp.spec "std::operator<=>(std::__cmp_cat::__unspec, std::strong_ordering)" as unspec_cmp_strong_ordering from source with (
+    \arg{lhs} "" (Vptr lhs)
+    \arg{rhs} "" (Vptr rhs)
+    \pre{q_lhs} lhs |-> unspecR q_lhs
+    \prepost{q_rhs rhs_v} rhs |-> strong_orderingR q_rhs rhs_v
+    \post{result}[Vptr result] result |-> strong_orderingR 1$m (CompOpp rhs_v) ** lhs |-> unspecR q_lhs).
+
+  cpp.spec "std::operator<=>(std::__cmp_cat::__unspec, std::weak_ordering)" as unspec_cmp_weak_ordering from source with (
+    \arg{lhs} "" (Vptr lhs)
+    \arg{rhs} "" (Vptr rhs)
+    \pre{q_lhs} lhs |-> unspecR q_lhs
+    \prepost{q_rhs rhs_v} rhs |-> weak_orderingR q_rhs rhs_v
+    \post{result}[Vptr result] result |-> weak_orderingR 1$m (CompOpp rhs_v) ** lhs |-> unspecR q_lhs).
+
+  cpp.spec "std::is_eq(std::partial_ordering)" as is_eq from source with (
+    \arg{cmp} "__cmp" (Vptr cmp)
+    \prepost{q v} cmp |-> partial_orderingR q v
+    \post[Vbool (bool_decide (v = Some Eq))] emp).
+
+  cpp.spec "std::is_lt(std::partial_ordering)" as is_lt from source with (
+    \arg{cmp} "__cmp" (Vptr cmp)
+    \prepost{q v} cmp |-> partial_orderingR q v
+    \post[Vbool (bool_decide (v = Some Lt))] emp).
+
+  cpp.spec "std::is_gt(std::partial_ordering)" as is_gt from source with (
+    \arg{cmp} "__cmp" (Vptr cmp)
+    \prepost{q v} cmp |-> partial_orderingR q v
+    \post[Vbool (bool_decide (v = Some Gt))] emp).
+
+  Definition specs :=
+    strong_ordering_copy_ctor **
+    strong_ordering_move_ctor **
+    strong_ordering_dtor **
+    partial_ordering_dtor **
+    partial_ordering_copy_ctor **
+    partial_ordering_move_ctor **
+    weak_ordering_copy_ctor **
+    weak_ordering_move_ctor **
+    weak_ordering_dtor **
+    strong_ordering_eq **
+    partial_ordering_eq **
+    weak_ordering_eq **
+    strong_to_partial **
+    weak_to_partial **
+    unspec_ctor **
+    unspec_dtor **
+    partial_ordering_eq_unspec **
+    partial_ordering_lt_unspec **
+    partial_ordering_gt_unspec **
+    partial_ordering_cmp_unspec **
+    strong_ordering_lt_unspec **
+    strong_ordering_eq_unspec **
+    strong_ordering_gt_unspec **
+    strong_ordering_cmp_unspec **
+    weak_ordering_eq_unspec **
+    weak_ordering_gt_unspec **
+    weak_ordering_cmp_unspec **
+    unspec_lt_partial_ordering **
+    unspec_cmp_partial_ordering **
+    unspec_gt_strong_ordering **
+    unspec_cmp_strong_ordering **
+    unspec_cmp_weak_ordering **
+    is_eq **
+    is_lt **
+    is_gt.
+  #[global] Hint Opaque specs : typeclass_instances sl_opacity.
+  #[only(knowledge)] derive specs.
+
+End with_cpp.
+
+NES.End std.compare.

--- a/rocq-brick-libstdcpp/proof/dune.inc
+++ b/rocq-brick-libstdcpp/proof/dune.inc
@@ -35,6 +35,18 @@
   	 (with-stderr-to inc_cctype_cpp.v.stderr (run cpp2v -v %{input} -o inc_cctype_cpp.v --no-elaborate --templates=inc_cctype_cpp_templates.v  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps inc_cctype.cpp))
 )
+(subdir compare
+ (rule
+  (targets inc_compare_cpp.v.stderr inc_compare_cpp.v inc_compare_cpp_templates.v)
+  (alias test_ast)
+  (deps
+   (:input inc_compare.cpp)
+   (env_var CPP2V_DOCKER_ENABLED)
+   (glob_files_rec ../*.hpp))
+  (action
+  	 (with-stderr-to inc_compare_cpp.v.stderr (run cpp2v -v %{input} -o inc_compare_cpp.v --no-elaborate --templates=inc_compare_cpp_templates.v  -- -std=c++20 -stdlib=libstdc++ ))))
+ (alias (name srcs) (deps inc_compare.cpp))
+)
 (subdir cstdlib
  (rule
   (targets inc_cstdlib_cpp.v.stderr inc_cstdlib_cpp.v inc_cstdlib_cpp_templates.v)

--- a/rocq-brick-libstdcpp/test/compare/floating_box.v
+++ b/rocq-brick-libstdcpp/test/compare/floating_box.v
@@ -1,0 +1,62 @@
+(*
+ * Copyright (c) 2026 SkyLabs AI, Inc.
+ * This software is distributed under the terms of the BedRock Open-Source License.
+ * See the LICENSE-BedRock file in the repository root for details.
+ *)
+Require Import skylabs.auto.cpp.prelude.spec.
+
+Require Import skylabs.brick.libstdcpp.compare.pred.
+Require Import skylabs.brick.libstdcpp.test.compare.test_cpp.
+
+Record FloatingBox := {
+  floating_box_value : float_type.car float_type.Fdouble;
+}.
+#[only(eq_dec)] derive FloatingBox.
+
+#[global] Instance SplitRecord_FloatingBox : SplitRecord FloatingBox := {}.
+
+Definition floating_box_compare (p p' : FloatingBox) : option comparison :=
+  float_value.value_compare
+    p.(floating_box_value) p'.(floating_box_value).
+
+
+sl.lock
+Definition FloatingBoxR `{Σ : cpp_logic, σ : genv} (q : cQp.t) (p : FloatingBox) : Rep :=
+  structR "FloatingBox" q **
+  _field "FloatingBox::value" |-> primR Tdouble q (Vfloat float_type.Fdouble p.(floating_box_value)).
+#[only(cfracsplittable,type_ptr,lazy_unfold(global))] derive FloatingBoxR.
+
+
+Section with_cpp.
+  Context `{Σ : cpp_logic}.
+  Context `{MOD : test_cpp.source ⊧ σ}.
+
+  cpp.spec "FloatingBox::~FloatingBox()" as floating_box_dtor with (
+    \this this
+    \pre{m} this |-> FloatingBoxR 1$m m
+    \post emp).
+
+  cpp.spec "FloatingBox::operator==(const FloatingBox&) const" as floating_box_eq with (
+    \this this
+    \arg{other} "" (Vref other)
+    \prepost{q_this m} this |-> FloatingBoxR q_this m
+    \prepost{q_other m'} other |-> FloatingBoxR q_other m'
+    \post[Vbool (bool_decide (floating_box_compare m m' = Some Eq))] emp).
+
+  cpp.spec "FloatingBox::operator<=>(const FloatingBox&) const" as floating_box_spaceship with (
+    \this this
+    \arg{other} "" (Vref other)
+    \prepost{q_globals} std.compare.partial_ordering_globals q_globals
+    \prepost std.compare.strong_ordering_globals q_globals
+    \prepost{q_this m} this |-> FloatingBoxR q_this m
+    \prepost{q_other m'} other |-> FloatingBoxR q_other m'
+    \post{result}[Vptr result]
+      result |-> std.compare.partial_orderingR 1$m (floating_box_compare m m')).
+
+  Definition floating_box_specs :=
+    floating_box_dtor **
+    floating_box_eq **
+    floating_box_spaceship.
+  #[global] Hint Opaque floating_box_specs : typeclass_instances sl_opacity.
+  #[only(knowledge)] derive floating_box_specs.
+End with_cpp.

--- a/rocq-brick-libstdcpp/test/compare/int_point.v
+++ b/rocq-brick-libstdcpp/test/compare/int_point.v
@@ -1,0 +1,63 @@
+(*
+ * Copyright (c) 2026 SkyLabs AI, Inc.
+ * This software is distributed under the terms of the BedRock Open-Source License.
+ * See the LICENSE-BedRock file in the repository root for details.
+ *)
+Require Import skylabs.auto.cpp.prelude.spec.
+
+Require Import skylabs.brick.libstdcpp.compare.pred.
+Require Import skylabs.brick.libstdcpp.test.compare.test_cpp.
+
+Record IntPoint := {
+  int_point_x : Z;
+  int_point_y : Z;
+}.
+#[only(eq_dec)] derive IntPoint.
+
+#[global] Instance SplitRecord_IntPoint : SplitRecord IntPoint := {}.
+
+Definition int_point_compare (p p' : IntPoint) : comparison :=
+  compare.compare_lex
+    (Z.compare p.(int_point_x) p'.(int_point_x))
+    (fun _ => Z.compare p.(int_point_y) p'.(int_point_y)).
+
+sl.lock
+Definition IntPointR `{Σ : cpp_logic, σ : genv} (q : cQp.t) (p : IntPoint) : Rep :=
+  structR "IntPoint" q **
+  _field "IntPoint::x" |-> primR Tint q (Vint p.(int_point_x)) **
+  _field "IntPoint::y" |-> primR Tint q (Vint p.(int_point_y)).
+#[only(cfracsplittable,type_ptr,lazy_unfold(global))] derive IntPointR.
+
+Section with_cpp.
+  Context `{Σ : cpp_logic}.
+  Context `{MOD : test_cpp.source ⊧ σ}.
+
+  cpp.spec "IntPoint::~IntPoint()" as int_point_dtor with (
+    \this this
+    \pre{m} this |-> IntPointR 1$m m
+    \post emp).
+
+  cpp.spec "IntPoint::operator==(const IntPoint&) const" as int_point_eq with (
+    \this this
+    \arg{other} "" (Vref other)
+    \prepost{q_this m} this |-> IntPointR q_this m
+    \prepost{q_other m'} other |-> IntPointR q_other m'
+    \post[Vbool (bool_decide (m = m'))] emp).
+
+  cpp.spec "IntPoint::operator<=>(const IntPoint&) const" as int_point_spaceship with (
+    \this this
+    \arg{other} "" (Vref other)
+    \prepost{q_globals} std.compare.strong_ordering_globals q_globals
+    \prepost{q_this m} this |-> IntPointR q_this m
+    \prepost{q_other m'} other |-> IntPointR q_other m'
+    \post{result}[Vptr result]
+      result |-> std.compare.strong_orderingR 1$m (int_point_compare m m')).
+
+  Definition int_point_specs :=
+    int_point_dtor **
+    int_point_eq **
+    int_point_spaceship.
+  #[global] Hint Opaque int_point_specs : typeclass_instances sl_opacity.
+  #[only(knowledge)] derive int_point_specs.
+
+End with_cpp.

--- a/rocq-brick-libstdcpp/test/compare/test.cpp
+++ b/rocq-brick-libstdcpp/test/compare/test.cpp
@@ -1,0 +1,159 @@
+/**
+ * Copyright (c) 2026 SkyLabs AI, Inc.
+ * This software is distributed under the terms of the BedRock Open-Source License.
+ * See the LICENSE-BedRock file in the repository root for details.
+ */
+#include <cassert>
+#include <compare>
+#include <limits>
+
+struct IntPoint {
+    int x;
+    int y;
+
+    auto operator<=>(const IntPoint&) const = default;
+};
+
+struct WeakBucket {
+    int key;
+
+    friend std::weak_ordering
+    operator<=>(const WeakBucket& lhs, const WeakBucket& rhs) {
+        int lhs_bucket = lhs.key / 10;
+        int rhs_bucket = rhs.key / 10;
+        if (lhs_bucket < rhs_bucket) {
+            return std::weak_ordering::less;
+        }
+        if (rhs_bucket < lhs_bucket) {
+            return std::weak_ordering::greater;
+        }
+        return std::weak_ordering::equivalent;
+    }
+
+    friend bool
+    operator==(const WeakBucket& lhs, const WeakBucket& rhs) {
+        return lhs.key / 10 == rhs.key / 10;
+    }
+};
+
+struct FloatingBox {
+    double value;
+
+    auto operator<=>(const FloatingBox&) const = default;
+};
+
+bool
+TestIntegralSpaceship() {
+    std::strong_ordering less = 1 <=> 2;
+    std::strong_ordering equal = 7 <=> 7;
+    std::strong_ordering greater = 9 <=> 3;
+
+    return std::is_lt(less) &&
+           (std::is_eq(equal) &&
+           (std::is_gt(greater) &&
+           (less == std::strong_ordering::less &&
+           (equal == std::strong_ordering::equal &&
+           greater == std::strong_ordering::greater))));
+}
+
+bool
+TestFloatingSpaceship() {
+    double nan = std::numeric_limits<double>::quiet_NaN();
+    std::partial_ordering less = 1.0 <=> 2.0;
+    std::partial_ordering equal = 3.0 <=> 3.0;
+    std::partial_ordering greater = 4.0 <=> -1.0;
+    std::partial_ordering unordered = nan <=> 1.0;
+
+    return std::is_lt(less) &&
+           (std::is_eq(equal) &&
+           (std::is_gt(greater) &&
+           (less == std::partial_ordering::less &&
+           (equal == std::partial_ordering::equivalent &&
+           (greater == std::partial_ordering::greater &&
+           (unordered == std::partial_ordering::unordered &&
+           (!std::is_lt(unordered) &&
+           (!std::is_eq(unordered) &&
+           !std::is_gt(unordered)))))))));
+}
+
+bool
+TestComparisonCategories() {
+    std::strong_ordering strong = std::strong_ordering::less;
+    std::weak_ordering weak = std::weak_ordering::equivalent;
+    std::partial_ordering partial = std::partial_ordering::unordered;
+    std::partial_ordering from_strong = strong;
+    std::partial_ordering from_weak = weak;
+
+    return strong < 0 &&
+           (0 > strong &&
+           ((strong <=> 0) == std::strong_ordering::less &&
+           ((0 <=> strong) == std::strong_ordering::greater &&
+           (weak == 0 &&
+           (0 == weak &&
+           ((weak <=> 0) == std::weak_ordering::equivalent &&
+           ((0 <=> weak) == std::weak_ordering::equivalent &&
+           (!(partial < 0) &&
+           (!(0 < partial) &&
+           ((partial <=> 0) == std::partial_ordering::unordered &&
+           ((0 <=> partial) == std::partial_ordering::unordered &&
+           (from_strong < 0 &&
+           from_weak == 0))))))))))));
+}
+
+bool
+TestDefaultedIntegerClass() {
+    IntPoint a{1, 2};
+    IntPoint b{1, 3};
+    IntPoint c{2, 0};
+    IntPoint same{1, 2};
+
+    return (a <=> b) == std::strong_ordering::less &&
+           ((c <=> b) == std::strong_ordering::greater &&
+           (a < b &&
+           (c > b &&
+           (a == same &&
+           !(a == b)))));
+}
+
+bool
+TestWeakOrderingClass() {
+    WeakBucket a{11};
+    WeakBucket b{19};
+    WeakBucket c{25};
+
+    return (a <=> b) == std::weak_ordering::equivalent &&
+           ((a <=> c) == std::weak_ordering::less &&
+           ((c <=> a) == std::weak_ordering::greater &&
+           (a == b &&
+           c > a)));
+}
+
+bool
+TestDefaultedFloatingClass() {
+    FloatingBox a{1.0};
+    FloatingBox b{2.0};
+    FloatingBox same{1.0};
+    FloatingBox nan{std::numeric_limits<double>::quiet_NaN()};
+
+    std::partial_ordering less = a <=> b;
+    std::partial_ordering unordered = nan <=> a;
+
+    return less == std::partial_ordering::less &&
+           (a < b &&
+           (a == same &&
+           (unordered == std::partial_ordering::unordered &&
+           (!(nan == a) &&
+           (!(nan < a) &&
+           !(nan > a))))));
+}
+
+int
+main() {
+    assert(TestIntegralSpaceship());
+    assert(TestFloatingSpaceship());
+    assert(TestComparisonCategories());
+    assert(TestDefaultedIntegerClass());
+    assert(TestWeakOrderingClass());
+    assert(TestDefaultedFloatingClass());
+    return 0;
+}

--- a/rocq-brick-libstdcpp/test/compare/test_cpp_proof.v
+++ b/rocq-brick-libstdcpp/test/compare/test_cpp_proof.v
@@ -1,0 +1,253 @@
+(*
+ * Copyright (c) 2026 SkyLabs AI, Inc.
+ * This software is distributed under the terms of the BedRock Open-Source License.
+ * See the LICENSE-BedRock file in the repository root for details.
+ *)
+Require Import skylabs.auto.cpp.prelude.test.
+
+Require Import skylabs.brick.libstdcpp.cassert.spec.
+Require Import skylabs.brick.libstdcpp.compare.spec.
+Require Import skylabs.brick.libstdcpp.compare.hints.
+Require Import skylabs.brick.libstdcpp.test.compare.test_cpp.
+
+Require Import skylabs.brick.libstdcpp.test.compare.int_point.
+Require Import skylabs.brick.libstdcpp.test.compare.weak_bucket.
+Require Import skylabs.brick.libstdcpp.test.compare.floating_box.
+Require Import skylabs.brick.libstdcpp.test.compare.test_specs.
+
+Import linearity.
+
+(* Test Warnings. *)
+#[local] Set Warnings "+sl-transparent-constants".
+(* Test Warnings. *)
+
+#[local] Set Default Goal Selector "!".
+
+Section with_cpp.
+  Context `{Σ : cpp_logic}.
+  Context `{MOD : test_cpp.source ⊧ σ}.
+
+  (*
+  Lemma valid_quot (z d : Z) :
+    0 < d ->
+    valid<"int"> (Vint z) ->
+    (* valid<"int"> (Vint (z `quot` d)). *)
+    bitsize.bound bitsize.W32 Signed (z `quot` d).
+  Proof.
+    intros.
+
+    type.has_type_prop_prep.
+    arith_simpl.
+    destruct (decide (0 <= z)).
+    {
+      suff: 0 <= z `quot` d < 2147483648 by lia.
+      apply Z.quot_range_nonneg; lia.
+    }
+    suff: 0 <= -z `quot` d < 2147483649 by lia.
+    rewrite -Z.quot_opp_l; last lia.
+    apply Z.quot_range_nonneg; lia.
+  Qed.
+  *)
+
+  (* Hint Resolve valid_quot : pure. *)
+
+  Lemma valid_quot' (z d : Z) :
+    0 <> d ->
+    valid<"int"> (Vint (z * Z.sgn d)) ->
+    (* valid<"int"> (Vint (z `quot` d)). *)
+    bitsize.bound bitsize.W32 Signed (z `quot` d).
+  Proof.
+    intros Hd Hz.
+    wlog: d Hd z Hz / 0 < d => [|{}Hd]. {
+      destruct (decide (0 < d)); first exact.
+
+      (* Search (- - ?x = ?x)%Z. *)
+      rewrite -(Z.opp_involutive d) Z.quot_opp_r -?Z.quot_opp_l; [|lia..].
+      apply; try lia.
+      move: Hz.
+      rewrite (Z.sgn_neg d) ?(Z.sgn_pos (-d)); arith_solve.
+    }
+    (* apply valid_quot; arith_solve. *)
+    intros.
+
+    type.has_type_prop_prep.
+    rewrite Z.sgn_pos in Hz; last lia.
+    arith_simpl.
+    destruct (decide (0 <= z)).
+    {
+      suff: 0 <= z `quot` d < 2147483648 by lia.
+      apply Z.quot_range_nonneg; lia.
+    }
+    suff: 0 <= -z `quot` d < 2147483649 by lia.
+    rewrite -Z.quot_opp_l; last lia.
+    apply Z.quot_range_nonneg; lia.
+  Qed.
+  #[local] Hint Resolve valid_quot' : pure.
+
+  Section proofs.
+    Lemma int_point_dtor_ok :
+      verify[ source ] int_point_dtor.
+    Proof using MOD.
+      verify_spec.
+      go.
+    Qed.
+    Definition int_point_dtor_B := [LINK] int_point_dtor_ok.
+    #[local] Hint Resolve int_point_dtor_B : sl_opacity.
+
+    Lemma int_point_eq_ok :
+      verify[ source ] int_point_eq.
+    Proof using MOD.
+      verify_spec.
+      go.
+      (* destruct m, m'. *)
+      vc_split; go; iPureIntro.
+      { destruct m, m'. naive_solver. }
+      { case_bool_decide; naive_solver. }
+    Qed.
+    Definition int_point_eq_B := [LINK] int_point_eq_ok.
+    #[local] Hint Resolve int_point_eq_B : sl_opacity.
+
+    Lemma int_point_spaceship_ok :
+      verify[ source ] int_point_spaceship.
+    Proof using MOD.
+      verify_spec.
+      go.
+      destruct (Z.compare (int_point_x _)) eqn:Hx; go.
+      1: destruct (Z.compare (int_point_y _)) eqn:Hy; go.
+      all: by rewrite /int_point_compare Hx ?Hy /=.
+    Qed.
+    Definition int_point_spaceship_B := [LINK] int_point_spaceship_ok.
+    #[local] Hint Resolve int_point_spaceship_B : sl_opacity.
+
+    Lemma weak_bucket_dtor_ok :
+      verify[ source ] weak_bucket_dtor.
+    Proof using MOD.
+      verify_spec.
+      go.
+    Qed.
+    Definition weak_bucket_dtor_B := [LINK] weak_bucket_dtor_ok.
+    #[local] Hint Resolve weak_bucket_dtor_B : sl_opacity.
+
+    Lemma weak_bucket_eq_ok :
+      verify[ source ] weak_bucket_eq.
+    Proof using MOD. verify_spec; go. Qed.
+
+    Definition weak_bucket_eq_B := [LINK] weak_bucket_eq_ok.
+    #[local] Hint Resolve weak_bucket_eq_B : sl_opacity.
+
+    Lemma weak_bucket_spaceship_ok :
+      verify[ source ] weak_bucket_spaceship.
+    Proof using MOD.
+      verify_spec.
+      go.
+      wp_if; go.
+      wp_if; go.
+      all: progress rewrite /weak_bucket_compare/weak_bucket_bucket/=.
+      { by rewrite Zaux.Zcompare_Gt. }
+      { by rewrite Zaux.Zcompare_Eq. }
+    Qed.
+    Definition weak_bucket_spaceship_B := [LINK] weak_bucket_spaceship_ok.
+    #[local] Hint Resolve weak_bucket_spaceship_B : sl_opacity.
+
+    Lemma floating_box_dtor_ok :
+      verify[ source ] floating_box_dtor.
+    Proof using MOD.
+      verify_spec.
+      go.
+    Qed.
+    Definition floating_box_dtor_B := [LINK] floating_box_dtor_ok.
+    #[local] Hint Resolve floating_box_dtor_B : sl_opacity.
+
+    Lemma floating_box_eq_ok :
+      verify[ source ] floating_box_eq.
+    Proof using MOD.
+      verify_spec.
+      go.
+    Qed.
+    Definition floating_box_eq_B := [LINK] floating_box_eq_ok.
+    #[local] Hint Resolve floating_box_eq_B : sl_opacity.
+
+    Lemma floating_box_spaceship_ok :
+      verify[ source ] floating_box_spaceship.
+    Proof using MOD.
+      verify_spec; go.
+      destruct float_value.value_compare as [[]|] eqn:Hx; go.
+    Qed.
+    Definition floating_box_spaceship_B := [LINK] floating_box_spaceship_ok.
+    #[local] Hint Resolve floating_box_spaceship_B : sl_opacity.
+
+    Lemma test_integral_spaceship_ok :
+      verify[ source ] test_integral_spaceship.
+    Proof using MOD.
+      verify_spec.
+      go.
+    Qed.
+    Definition test_integral_spaceship_B := [LINK] test_integral_spaceship_ok.
+    #[local] Hint Resolve test_integral_spaceship_B : sl_opacity.
+
+    Lemma test_floating_spaceship_ok :
+      verify[ source ] test_floating_spaceship.
+    Proof using MOD.
+      verify_spec.
+      go.
+    Qed.
+    Definition test_floating_spaceship_B := [LINK] test_floating_spaceship_ok.
+    #[local] Hint Resolve test_floating_spaceship_B : sl_opacity.
+
+    Lemma test_comparison_categories_ok :
+      verify[ source ] test_comparison_categories.
+    Proof using MOD.
+      verify_spec.
+      Time go.
+    Qed.
+    Definition test_comparison_categories_B := [LINK] test_comparison_categories_ok.
+    #[local] Hint Resolve test_comparison_categories_B : sl_opacity.
+
+    Lemma test_defaulted_integer_class_ok :
+      verify?[ source ] test_defaulted_integer_class.
+    Proof using MOD.
+      verify_spec.
+      go.
+    Qed.
+    Definition test_defaulted_integer_class_B := [LINK] test_defaulted_integer_class_ok.
+    #[local] Hint Resolve test_defaulted_integer_class_B : sl_opacity.
+
+    Lemma test_weak_ordering_class_ok :
+      verify[ source ] test_weak_ordering_class.
+    Proof using MOD.
+      verify_spec.
+      go.
+    Qed.
+    Definition test_weak_ordering_class_B := [LINK] test_weak_ordering_class_ok.
+    #[local] Hint Resolve test_weak_ordering_class_B : sl_opacity.
+
+    Lemma test_defaulted_floating_class_ok :
+      verify[ source ] test_defaulted_floating_class.
+    Proof using MOD.
+      verify_spec.
+      go.
+    Qed.
+    Definition test_defaulted_floating_class_B := [LINK] test_defaulted_floating_class_ok.
+    #[local] Hint Resolve test_defaulted_floating_class_B : sl_opacity.
+
+    Lemma main_ok :
+      verify[ source ] main.
+    Proof using MOD.
+      verify_spec.
+      go.
+    Qed.
+    Definition main_B := [LINK] main_ok.
+    #[local] Hint Resolve main_B : sl_opacity.
+
+    Lemma specs_ok :
+      denoteModule source **
+      ▷ test_quiet_NaN **
+      ▷ (std.cassert.specs
+      ** std.compare.specs)
+      |-- main.
+    Proof using MOD.
+      rewrite /std.cassert.specs /std.compare.specs.
+      work.
+    Qed.
+  End proofs.
+End with_cpp.

--- a/rocq-brick-libstdcpp/test/compare/test_specs.v
+++ b/rocq-brick-libstdcpp/test/compare/test_specs.v
@@ -1,0 +1,66 @@
+(*
+ * Copyright (c) 2026 SkyLabs AI, Inc.
+ * This software is distributed under the terms of the BedRock Open-Source License.
+ * See the LICENSE-BedRock file in the repository root for details.
+ *)
+Require Import skylabs.auto.cpp.prelude.spec.
+
+Require Import skylabs.brick.libstdcpp.compare.pred.
+
+Require Import skylabs.brick.libstdcpp.test.compare.int_point.
+Require Import skylabs.brick.libstdcpp.test.compare.weak_bucket.
+Require Import skylabs.brick.libstdcpp.test.compare.floating_box.
+
+Require Import skylabs.brick.libstdcpp.test.compare.test_cpp.
+
+Section with_cpp.
+  Context `{Σ : cpp_logic}.
+  Context `{MOD : test_cpp.source ⊧ σ}.
+
+  cpp.spec "TestIntegralSpaceship()" as test_integral_spaceship with (
+    \prepost{q_globals} std.compare.strong_ordering_globals q_globals
+    \post[Vbool true] emp).
+
+  (* TODO: quiet_NaN returns an arbitrary quiet NaN, not necessarily this one. *)
+  cpp.spec "std::numeric_limits<double>::quiet_NaN()" as test_quiet_NaN from source with (
+    \post[Vfloat float_type.Fdouble (proj1_sig (float_value.default_nan float_type.Fdouble))] emp).
+
+  cpp.spec "TestFloatingSpaceship()" as test_floating_spaceship with (
+    \prepost{q_globals} std.compare.partial_ordering_globals q_globals
+    \post[Vbool true] emp).
+
+  cpp.spec "TestComparisonCategories()" as test_comparison_categories with (
+    \prepost{q_globals} std.compare.compare_globals q_globals
+    \post[Vbool true] emp).
+
+  cpp.spec "TestDefaultedIntegerClass()" as test_defaulted_integer_class with (
+    \prepost{q_globals} std.compare.strong_ordering_globals q_globals
+    \post[Vbool true] emp).
+
+  cpp.spec "TestWeakOrderingClass()" as test_weak_ordering_class with (
+    \prepost{q_globals} std.compare.weak_ordering_globals q_globals
+    \post[Vbool true] emp).
+
+  cpp.spec "TestDefaultedFloatingClass()" as test_defaulted_floating_class with (
+    \prepost{q_globals} std.compare.partial_ordering_globals q_globals
+    \prepost std.compare.strong_ordering_globals q_globals
+    \post[Vbool true] emp).
+
+  cpp.spec "main()" as main with (
+    \prepost{q_globals} std.compare.compare_globals q_globals
+    \post[Vint 0] emp).
+
+  Definition specs :=
+    int_point_specs **
+    weak_bucket_specs **
+    floating_box_specs **
+    test_integral_spaceship **
+    test_quiet_NaN **
+    test_floating_spaceship **
+    test_comparison_categories **
+    test_defaulted_integer_class **
+    test_weak_ordering_class **
+    test_defaulted_floating_class **
+    main.
+
+End with_cpp.

--- a/rocq-brick-libstdcpp/test/compare/weak_bucket.v
+++ b/rocq-brick-libstdcpp/test/compare/weak_bucket.v
@@ -1,0 +1,67 @@
+(*
+ * Copyright (c) 2026 SkyLabs AI, Inc.
+ * This software is distributed under the terms of the BedRock Open-Source License.
+ * See the LICENSE-BedRock file in the repository root for details.
+ *)
+Require Import skylabs.auto.cpp.prelude.spec.
+
+Require Import skylabs.brick.libstdcpp.compare.pred.
+Require Import skylabs.brick.libstdcpp.test.compare.test_cpp.
+
+Record WeakBucket := {
+  weak_bucket_key : Z;
+}.
+#[only(eq_dec)] derive WeakBucket.
+
+#[global] Instance SplitRecord_WeakBucket : SplitRecord WeakBucket := {}.
+
+Definition weak_bucket_bucket (p : WeakBucket) : Z :=
+  Z.quot p.(weak_bucket_key) 10.
+
+Definition weak_bucket_equivalent : relation WeakBucket :=
+  option.on eq weak_bucket_bucket.
+
+Definition weak_bucket_compare (p p' : WeakBucket) : comparison :=
+  Z.compare (weak_bucket_bucket p) (weak_bucket_bucket p').
+
+
+sl.lock
+Definition WeakBucketR `{Σ : cpp_logic, σ : genv} (q : cQp.t) (p : WeakBucket) : Rep :=
+  structR "WeakBucket" q **
+  _field "WeakBucket::key" |-> primR Tint q (Vint p.(weak_bucket_key)).
+#[only(cfracsplittable,type_ptr,lazy_unfold(global))] derive WeakBucketR.
+
+
+Section with_cpp.
+  Context `{Σ : cpp_logic}.
+  Context `{MOD : test_cpp.source ⊧ σ}.
+
+  cpp.spec "WeakBucket::~WeakBucket()" as weak_bucket_dtor with (
+    \this this
+    \pre{m} this |-> WeakBucketR 1$m m
+    \post emp).
+
+  cpp.spec "operator==(const WeakBucket&, const WeakBucket&)" as weak_bucket_eq with (
+    \arg{lhs} "lhs" (Vref lhs)
+    \arg{rhs} "rhs" (Vref rhs)
+    \prepost{q_lhs lhs_m} lhs |-> WeakBucketR q_lhs lhs_m
+    \prepost{q_rhs rhs_m} rhs |-> WeakBucketR q_rhs rhs_m
+    \post[Vbool (bool_decide (weak_bucket_equivalent lhs_m rhs_m))] emp).
+
+  cpp.spec "operator<=>(const WeakBucket&, const WeakBucket&)" as weak_bucket_spaceship with (
+    \arg{lhs} "lhs" (Vref lhs)
+    \arg{rhs} "rhs" (Vref rhs)
+    \prepost{q_globals} std.compare.weak_ordering_globals q_globals
+    \prepost{q_lhs lhs_m} lhs |-> WeakBucketR q_lhs lhs_m
+    \prepost{q_rhs rhs_m} rhs |-> WeakBucketR q_rhs rhs_m
+    \post{result}[Vptr result]
+      result |-> std.compare.weak_orderingR 1$m (weak_bucket_compare lhs_m rhs_m)).
+
+  Definition weak_bucket_specs :=
+    weak_bucket_dtor **
+    weak_bucket_eq **
+    weak_bucket_spaceship.
+  #[global] Hint Opaque weak_bucket_specs : typeclass_instances sl_opacity.
+  #[only(knowledge)] derive weak_bucket_specs.
+
+End with_cpp.

--- a/rocq-brick-libstdcpp/test/dune.inc
+++ b/rocq-brick-libstdcpp/test/dune.inc
@@ -11,6 +11,18 @@
   	 (with-stderr-to test_cpp.v.stderr (run cpp2v -v %{input} -o test_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
  (alias (name srcs) (deps test.cpp))
 )
+(subdir compare
+ (rule
+  (targets test_cpp.v.stderr test_cpp.v)
+  (alias test_ast)
+  (deps
+   (:input test.cpp)
+   (env_var CPP2V_DOCKER_ENABLED)
+   (glob_files_rec ../*.hpp))
+  (action
+  	 (with-stderr-to test_cpp.v.stderr (run cpp2v -v %{input} -o test_cpp.v --no-elaborate  -- -std=c++20 -stdlib=libstdc++ ))))
+ (alias (name srcs) (deps test.cpp))
+)
 (subdir cstdlib
  (rule
   (targets test_cpp.v.stderr test_cpp.v)


### PR DESCRIPTION
Specify <compare> as needed, with spaceship hint, and add end-to-end test.

Part of https://github.com/SkyLabsAI/BRiCk/issues/148.