### PR TITLE
Map temporary files to the same path in vm

### DIFF
--- a/rocq-brick-libstdcpp/cpp2v_docker.in
+++ b/rocq-brick-libstdcpp/cpp2v_docker.in
@@ -3,6 +3,16 @@
 REALPATH=$(which grealpath || which realpath)
 REL_PATH="$($REALPATH `pwd` --relative-to "$DUNE_SOURCEROOT")"
 
+map_absolute_paths () {
+    while [[ $# -gt 0 ]]; do
+        if [[ $1 =~ /.*\.(v|cpp|hpp|h|c) ]] && [[ -f "$1" ]]; then
+            local dir="$(dirname "$1")"
+            echo "--volume" "$dir:$dir"
+        fi
+        shift
+    done
+}
+
 if [ -n "$IN_CPP2V_DOCKER" ]; then
   echo "Error: recursive invocation of \"cpp2v_docker\" as $0 from outer cpp2v_docker as ${IN_CPP2V_DOCKER}"
   echo "(PATH is $PATH)."
@@ -27,6 +37,7 @@ if [ "$CPP2V_DOCKER_ENABLED" = "y" ] && which docker > /dev/null; then
   ARGS+=( "--volume" "${HOME}/.cache/remote_dune:/home/coq/.cache/dune:cached" )
   ARGS+=( "--volume" "$DUNE_SOURCEROOT:$BRICK_LIBCPP" )
   ARGS+=( "--workdir" "$BRICK_LIBCPP/$REL_PATH" )
+  ARGS+=( $(map_absolute_paths "$@") )
 
   cpp2v_args="$( printf '"%q" ' "$@" )" # ensure each argument is quoted as a whole.
   docker run "${ARGS[@]}" "$CPP2V_DOCKER_IMAGE" \


### PR DESCRIPTION
The `cpp.prog` elpi command uses temporary files to call `cpp2v` on and those are mapped outside the workspace. This PR adds code to `cpp2v-docker` to scan the arguments to find absolute paths to identify directories outside the workspace and maps them in docker to the same path.