### PR TITLE
Fix three spec defects (atoi, semaphore, vector)

### DIFF
--- a/rocq-brick-libstdcpp/proof/cstdlib/atoi.v
+++ b/rocq-brick-libstdcpp/proof/cstdlib/atoi.v
@@ -22,19 +22,19 @@ Section with_cpp.
     (\arg{buf} "str" (Vptr buf)
      \prepost{q str} buf |-> cstring.R q str
      \require valid<"int"> (atoi str)
-     \post{n}[Vint n] emp).
+     \post[Vint (atoi str)] emp).
 
   cpp.spec "atol" with
     (\arg{buf} "str" (Vptr buf)
      \prepost{q str} buf |-> cstring.R q str
      \require valid<"long"> (atoi str)
-     \post{n}[Vint n] emp).
+     \post[Vint (atoi str)] emp).
 
   cpp.spec "atoll" with
     (\arg{buf} "str" (Vptr buf)
      \prepost{q str} buf |-> cstring.R q str
      \require valid<"long long"> (atoi str)
-     \post{n}[Vint n] emp).
+     \post[Vint (atoi str)] emp).
 
 End with_cpp.
 

--- a/rocq-brick-libstdcpp/proof/semaphore/spec.v
+++ b/rocq-brick-libstdcpp/proof/semaphore/spec.v
@@ -36,6 +36,7 @@ Section with_cpp.
   cpp.spec "std::counting_semaphore<1l>::counting_semaphore(long)" as ctor_spec with
       (\this this
        \arg{desired} "desired" (Vnat desired)
+       \require desired <= 1
        \post Exists g, this |-> semaphoreR g 1$m ** semaphore_Val g desired).
   (* note that technically mutex needs to know which thread holds it *)
 
@@ -47,7 +48,7 @@ Section with_cpp.
 
   Definition try_acquire_ac g Q : mpred :=
     AU <{ ∃∃ n, semaphore_Val g n }> @ top, empty
-       <{ semaphore_Val g (if bool_decide (n = 0) then n else n-1), COMM Q $ bool_decide (n = 0) }>.
+       <{ semaphore_Val g (if bool_decide (n <> 0) then n-1 else n), COMM Q $ bool_decide (n <> 0) }>.
   #[global] Hint Opaque try_acquire_ac : sl_opacity.
 
   cpp.spec "std::counting_semaphore<1l>::try_acquire()" as try_lock_spec with

--- a/rocq-brick-libstdcpp/proof/vector/spec.v
+++ b/rocq-brick-libstdcpp/proof/vector/spec.v
@@ -427,7 +427,7 @@ NES.Begin std.
           \post this |-> R_null (cQp.m 1).
       #[global] Hint Opaque ctor_with_alloc : sl_opacity.
       #[global] Arguments ctor_with_alloc : simpl never.
-      Definition SpecFor_ctor_with_alloc := RegisterSpec default_ctor.
+      Definition SpecFor_ctor_with_alloc := RegisterSpec (@ctor_with_alloc).
       #[global] Existing Instance SpecFor_ctor_with_alloc.
 
       Section allocator.


### PR DESCRIPTION
Three small spec fixes, found while proving client code against these contracts.

Note: these were surfaced by a new proof-backed spec-checking system we're building, not manually found. Part of the point of this PR is checking whether its output actually holds up.

- `atoi`/`atol`/`atoll`: postcondition wasn't tied to the conversion result (returned an arbitrary in-range int), so no caller could prove a concrete value.
- `counting_semaphore<1>::try_acquire`: result was inverted vs C++20 [thread.sema.cnt] (returned false on a successful decrement); ctor also didn't bound `desired` to the max count of 1.
- `vector`'s allocator ctor was registered under `SpecFor_ctor_with_alloc` as `default_ctor` (copy-paste), so the allocator-taking constructor had no spec.

Each commit is independent. Verified: the full package rebuilds with each fix applied, no regressions elsewhere.


