### PR TITLE
Specify constructing std::vector from a std::allocator

### DIFF
--- a/rocq-brick-libstdcpp/proof/allocator/spec.v
+++ b/rocq-brick-libstdcpp/proof/allocator/spec.v
@@ -38,4 +38,36 @@ NES.Begin std.allocator.
     {| size_type := "unsigned long" ;
        alloc_state := () |}.
 
+  Section with_cpp.
+    Context `{Σ : cpp_logic, σ : genv}.
+    Context (ty : type).
+
+    #[local] Abbreviation allocator := (N ty) (only parsing).
+
+    (* std::allocator<T> is stateless: the default constructor produces the
+       allocator object and the destructor consumes it. *)
+    Definition ctor :=
+      specify.template.ctor allocator [] $
+        \this this
+        \post this |-> R ty (cQp.m 1) ().
+    #[global] Hint Opaque ctor : sl_opacity.
+    #[global] Arguments ctor : simpl never.
+    Definition SpecFor_ctor := RegisterSpec ctor.
+    #[global] Existing Instance SpecFor_ctor.
+
+    Definition dtor :=
+      specify.template.dtor allocator $
+        \this this
+        \pre this |-> R ty (cQp.m 1) ()
+        \post emp.
+    #[global] Hint Opaque dtor : sl_opacity.
+    #[global] Arguments dtor : simpl never.
+    Definition SpecFor_dtor := RegisterSpec dtor.
+    #[global] Existing Instance SpecFor_dtor.
+
+    Definition specs := ctor ** dtor.
+    #[global] Hint Opaque specs : typeclass_instances sl_opacity.
+    #[only(knowledge)] derive specs.
+  End with_cpp.
+
 NES.End std.allocator.

--- a/rocq-brick-libstdcpp/proof/vector/spec.v
+++ b/rocq-brick-libstdcpp/proof/vector/spec.v
@@ -422,7 +422,7 @@ NES.Begin std.
       #[global] Existing Instance SpecFor_default_ctor.
 
       Definition ctor_with_alloc `{!BundledRep alloc_ty AllocT} :=
-        specify.template.ctor vector [alloc_ty] $
+        specify.template.ctor vector [Tref (Tconst alloc_ty)] $
           \this this
           \arg{allocp} "alloc" (Vptr allocp)
           \prepost{a} allocp |-> objR alloc_ty (cQp.m 1) a

--- a/rocq-brick-libstdcpp/test/vector/test.cpp
+++ b/rocq-brick-libstdcpp/test/vector/test.cpp
@@ -5,6 +5,7 @@
  */
 #include <algorithm>
 #include <cassert>
+#include <memory>
 #include <vector>
 
 using namespace std;
@@ -90,11 +91,19 @@ TestAggregate() {
     test(v.size() == 3);
 }
 
+void
+TestAllocCtor() {
+    allocator<int> a;
+    vector<int> v(a);
+    test(v.size() == 0);
+}
+
 int
 main() {
     TestBasic();
     TestAggregate();
     TestIntIter();
     TestForEach();
+    TestAllocCtor();
     return 0;
 }

--- a/rocq-brick-libstdcpp/test/vector/test_cpp_proof.v
+++ b/rocq-brick-libstdcpp/test/vector/test_cpp_proof.v
@@ -179,6 +179,9 @@ Section with_cpp.
     cpp.spec "TestForEach()" as test_for_each with
         (\post emp).
 
+    cpp.spec "TestAllocCtor()" as test_alloc_ctor with
+        (\post emp).
+
     cpp.spec "TestAggregate()" as test_aggregate with
         (\post emp).
 
@@ -255,6 +258,15 @@ Section with_cpp.
     Definition test_basic_B := [LINK] test_basic_ok.
     #[local] Hint Resolve test_basic_B : sl_opacity.
 
+    Lemma test_alloc_ctor_ok : verify[ source ] test_alloc_ctor.
+    Proof using MOD.
+      verify_spec.
+      go.
+      iExists (). iFrame. iIntros "?". go.
+    Qed.
+    Definition test_alloc_ctor_B := [LINK] test_alloc_ctor_ok.
+    #[local] Hint Resolve test_alloc_ctor_B : sl_opacity.
+
     Lemma test_aggregate_ok : verify[ source ] test_aggregate.
     Proof using MOD.
       verify_spec.
@@ -289,12 +301,14 @@ Section with_cpp.
           std.vector.iterator.specs true "unsigned" alloc_uint **
           std.vector.iterator.specs false "int" alloc_int **
           std.find_spec (std.vector.iterator.T "int") "int" source **
+          std.allocator.specs "int" **
           std.cassert.specs)
       |-- main.
     Proof using MOD.
       rewrite /std.vector.specs.
       rewrite /std.vector.iterator.specs.
       rewrite /std.cassert.specs.
+      rewrite /std.allocator.specs.
       work.
     Qed.
 


### PR DESCRIPTION
Two spec fixes for constructing a `std::vector` from an allocator, found
while proving client code against these contracts (the same proof-backed
spec-checking system behind #102).

- `std::allocator<T>`: the default constructor and destructor had no
  specification, so any client that constructs a `std::allocator` — e.g. to
  pass one to a container constructor — had no matching spec and could not
  be verified.
- `std::vector`'s `ctor_with_alloc` declared its allocator parameter by
  value, so it registered as `vector(std::allocator<int>)` rather than the
  standard's `vector(const std::allocator<int>&)`; no caller passing an
  allocator matched it. Now taken by const reference, consistent with the
  copy/move allocator constructors.

Each commit is independent. `test/vector/` gains a client that constructs a
`vector<int>` from a `std::allocator<int>` and proves against the updated
specs, exercising the allocator ctor/dtor and the vector constructor end to
end.

Verified: the touched families (`proof/allocator`, `proof/vector`,
`test/vector`) rebuild from a clean `_build` and the new client proof closes
with `Qed`.

Scope note: the sized (`vector(n, alloc)`) and fill (`vector(n, v, alloc)`)
allocator constructors have the same by-value parameter typing, but a client
validating them additionally needs a `DefaultValue` instance for the element
type; left for a follow-up so this PR stays minimal and fully tested.
