### PR TITLE
cstring/*cmp: fix *cmp specs

### DIFF
--- a/rocq-brick-libstdcpp/proof/cstring/spec.v
+++ b/rocq-brick-libstdcpp/proof/cstring/spec.v
@@ -19,6 +19,24 @@ Abbreviation search_result := (fun byte_ty p found =>
     | None => nullptr
     end)) (only parsing).
 
+Definition same_sign (source dest : Z) : Prop :=
+  match trichotomyT Z.lt source 0 with
+  | inleft (left H) => dest < 0
+  | inleft (right H) => dest = 0
+  | inright H => dest > 0
+  end.
+#[global] Arguments same_sign !_ /.
+
+Lemma same_sign_correct_lt s d :
+  same_sign s d -> s < 0 <-> d < 0.
+Proof. rewrite /same_sign; destruct trichotomyT as [[?|?]|?]; lia. Qed.
+Lemma same_sign_correct_eq s d :
+  same_sign s d -> s = 0 <-> d = 0.
+Proof. rewrite /same_sign; destruct trichotomyT as [[?|?]|?]; lia. Qed.
+Lemma same_sign_correct_gt s d :
+  same_sign s d -> s > 0 <-> d > 0.
+Proof. rewrite /same_sign; destruct trichotomyT as [[?|?]|?]; lia. Qed.
+
 Section with_cpp.
 Context `{Σ : cpp_logic, source ⊧ σ}.
 
@@ -33,7 +51,7 @@ Context `{Σ : cpp_logic, source ⊧ σ}.
      \arg{s2_p} "__s2" (Vptr s2_p)
      \prepost{q1 s1} s1_p |-> cstring.R q1 s1
      \prepost{q2 s2} s2_p |-> cstring.R q2 s2
-     \post[Vint (strcmp s1 s2)] emp).
+     \post{res}[Vint res] [| same_sign (strcmp s1 s2) res |] ).
 
   cpp.spec "strncmp" with
     (\arg{s1_p} "__s1" (Vptr s1_p)
@@ -41,7 +59,7 @@ Context `{Σ : cpp_logic, source ⊧ σ}.
      \arg{n} "__n" (Vn n)
      \prepost{q1 s1} s1_p |-> cstring.R q1 s1
      \prepost{q2 s2} s2_p |-> cstring.R q2 s2
-     \post[Vint (strncmp s1 s2 n)] emp).
+     \post{res}[Vint res] [| same_sign (strncmp s1 s2 n) res |] ).
 
   cpp.spec "strchr(char*, int)" as strchr_mut_spec with
     (\arg{s_p} "__s" (Vptr s_p)
@@ -166,7 +184,7 @@ Context `{Σ : cpp_logic, source ⊧ σ}.
      \arg{z} "__n" (Vint z)
      \prepost{q1 bytes1} s1_p |-> array_sliceR Tuchar 0 z (fun b : Z => ucharR q1 b) bytes1
      \prepost{q2 bytes2} s2_p |-> array_sliceR Tuchar 0 z (fun b : Z => ucharR q2 b) bytes2
-     \post[Vint (memcmp bytes1 bytes2)] emp).
+     \post{res}[Vint res] [| same_sign (memcmp bytes1 bytes2) res |] ).
 
   cpp.spec "memset" with
     (\arg{s_p} "__s" (Vptr s_p)

--- a/rocq-brick-libstdcpp/proof/cstring/spec.v
+++ b/rocq-brick-libstdcpp/proof/cstring/spec.v
@@ -19,8 +19,6 @@ Abbreviation byte_search_result := (fun byte_ty p found =>
     | None => nullptr
     end)) (only parsing).
 
-Abbreviation search_result := (byte_search_result Tchar) (only parsing).
-
 Section with_cpp.
 Context `{Σ : cpp_logic, source ⊧ σ}.
 
@@ -50,28 +48,28 @@ Context `{Σ : cpp_logic, source ⊧ σ}.
      \arg{c} "__c" (Vint c)
      \prepost{q s} s_p |-> cstring.R q s
      \require valid<"unsigned char"> c
-     \post[search_result s_p (strchr s c)] emp).
+     \post[byte_search_result Tchar s_p (strchr s c)] emp).
 
   cpp.spec "strchr(const char*, int)" as strchr_const_spec with
     (\arg{s_p} "__s" (Vptr s_p)
      \arg{c} "__c" (Vint c)
      \prepost{q s} s_p |-> cstring.R q s
      \require valid<"unsigned char"> c
-     \post[search_result s_p (strchr s c)] emp).
+     \post[byte_search_result Tchar s_p (strchr s c)] emp).
 
   cpp.spec "strrchr(char*, int)" as strrchr_mut_spec with
     (\arg{s_p} "__s" (Vptr s_p)
      \arg{c} "__c" (Vint c)
      \prepost{q s} s_p |-> cstring.R q s
      \require valid<"unsigned char"> c
-     \post[search_result s_p (strrchr s c)] emp).
+     \post[byte_search_result Tchar s_p (strrchr s c)] emp).
 
   cpp.spec "strrchr(const char*, int)" as strrchr_const_spec with
     (\arg{s_p} "__s" (Vptr s_p)
      \arg{c} "__c" (Vint c)
      \prepost{q s} s_p |-> cstring.R q s
      \require valid<"unsigned char"> c
-     \post[search_result s_p (strrchr s c)] emp).
+     \post[byte_search_result Tchar s_p (strrchr s c)] emp).
 
   cpp.spec "strspn" with
     (\arg{s_p} "__s" (Vptr s_p)
@@ -94,28 +92,28 @@ Context `{Σ : cpp_logic, source ⊧ σ}.
      \arg{accept_p} "__accept" (Vptr accept_p)
      \prepost{q s} s_p |-> cstring.R q s
      \prepost{accept_q accept} accept_p |-> cstring.R accept_q accept
-     \post[search_result s_p (strpbrk s accept)] emp).
+     \post[byte_search_result Tchar s_p (strpbrk s accept)] emp).
 
   cpp.spec "strpbrk(const char*, const char*)" as strpbrk_const_spec with
     (\arg{s_p} "__s" (Vptr s_p)
      \arg{accept_p} "__accept" (Vptr accept_p)
      \prepost{q s} s_p |-> cstring.R q s
      \prepost{accept_q accept} accept_p |-> cstring.R accept_q accept
-     \post[search_result s_p (strpbrk s accept)] emp).
+     \post[byte_search_result Tchar s_p (strpbrk s accept)] emp).
 
   cpp.spec "strstr(char*, const char*)" as strstr_mut_spec with
     (\arg{haystack_p} "__haystack" (Vptr haystack_p)
      \arg{needle_p} "__needle" (Vptr needle_p)
      \prepost{haystack_q haystack} haystack_p |-> cstring.R haystack_q haystack
      \prepost{needle_q needle} needle_p |-> cstring.R needle_q needle
-     \post[search_result haystack_p (strstr haystack needle)] emp).
+     \post[byte_search_result Tchar haystack_p (strstr haystack needle)] emp).
 
   cpp.spec "strstr(const char*, const char*)" as strstr_const_spec with
     (\arg{haystack_p} "__haystack" (Vptr haystack_p)
      \arg{needle_p} "__needle" (Vptr needle_p)
      \prepost{haystack_q haystack} haystack_p |-> cstring.R haystack_q haystack
      \prepost{needle_q needle} needle_p |-> cstring.R needle_q needle
-     \post[search_result haystack_p (strstr haystack needle)] emp).
+     \post[byte_search_result Tchar haystack_p (strstr haystack needle)] emp).
 
 (*  Strong but unsound before C++17, and awkward
   cpp.spec "memchr(void*, int, unsigned long)" as memchr_mut_spec with

--- a/rocq-brick-libstdcpp/proof/cstring/spec.v
+++ b/rocq-brick-libstdcpp/proof/cstring/spec.v
@@ -13,7 +13,7 @@ Require Import skylabs.brick.libstdcpp.cstring.inc_cstring_cpp.
 
 #[local] Open Scope Z_scope.
 
-Abbreviation byte_search_result := (fun byte_ty p found =>
+Abbreviation search_result := (fun byte_ty p found =>
   Vptr (match found with
     | Some off => (p .[ byte_ty ! off ])
     | None => nullptr
@@ -48,28 +48,28 @@ Context `{Σ : cpp_logic, source ⊧ σ}.
      \arg{c} "__c" (Vint c)
      \prepost{q s} s_p |-> cstring.R q s
      \require valid<"unsigned char"> c
-     \post[byte_search_result Tchar s_p (strchr s c)] emp).
+     \post[search_result Tchar s_p (strchr s c)] emp).
 
   cpp.spec "strchr(const char*, int)" as strchr_const_spec with
     (\arg{s_p} "__s" (Vptr s_p)
      \arg{c} "__c" (Vint c)
      \prepost{q s} s_p |-> cstring.R q s
      \require valid<"unsigned char"> c
-     \post[byte_search_result Tchar s_p (strchr s c)] emp).
+     \post[search_result Tchar s_p (strchr s c)] emp).
 
   cpp.spec "strrchr(char*, int)" as strrchr_mut_spec with
     (\arg{s_p} "__s" (Vptr s_p)
      \arg{c} "__c" (Vint c)
      \prepost{q s} s_p |-> cstring.R q s
      \require valid<"unsigned char"> c
-     \post[byte_search_result Tchar s_p (strrchr s c)] emp).
+     \post[search_result Tchar s_p (strrchr s c)] emp).
 
   cpp.spec "strrchr(const char*, int)" as strrchr_const_spec with
     (\arg{s_p} "__s" (Vptr s_p)
      \arg{c} "__c" (Vint c)
      \prepost{q s} s_p |-> cstring.R q s
      \require valid<"unsigned char"> c
-     \post[byte_search_result Tchar s_p (strrchr s c)] emp).
+     \post[search_result Tchar s_p (strrchr s c)] emp).
 
   cpp.spec "strspn" with
     (\arg{s_p} "__s" (Vptr s_p)
@@ -92,28 +92,28 @@ Context `{Σ : cpp_logic, source ⊧ σ}.
      \arg{accept_p} "__accept" (Vptr accept_p)
      \prepost{q s} s_p |-> cstring.R q s
      \prepost{accept_q accept} accept_p |-> cstring.R accept_q accept
-     \post[byte_search_result Tchar s_p (strpbrk s accept)] emp).
+     \post[search_result Tchar s_p (strpbrk s accept)] emp).
 
   cpp.spec "strpbrk(const char*, const char*)" as strpbrk_const_spec with
     (\arg{s_p} "__s" (Vptr s_p)
      \arg{accept_p} "__accept" (Vptr accept_p)
      \prepost{q s} s_p |-> cstring.R q s
      \prepost{accept_q accept} accept_p |-> cstring.R accept_q accept
-     \post[byte_search_result Tchar s_p (strpbrk s accept)] emp).
+     \post[search_result Tchar s_p (strpbrk s accept)] emp).
 
   cpp.spec "strstr(char*, const char*)" as strstr_mut_spec with
     (\arg{haystack_p} "__haystack" (Vptr haystack_p)
      \arg{needle_p} "__needle" (Vptr needle_p)
      \prepost{haystack_q haystack} haystack_p |-> cstring.R haystack_q haystack
      \prepost{needle_q needle} needle_p |-> cstring.R needle_q needle
-     \post[byte_search_result Tchar haystack_p (strstr haystack needle)] emp).
+     \post[search_result Tchar haystack_p (strstr haystack needle)] emp).
 
   cpp.spec "strstr(const char*, const char*)" as strstr_const_spec with
     (\arg{haystack_p} "__haystack" (Vptr haystack_p)
      \arg{needle_p} "__needle" (Vptr needle_p)
      \prepost{haystack_q haystack} haystack_p |-> cstring.R haystack_q haystack
      \prepost{needle_q needle} needle_p |-> cstring.R needle_q needle
-     \post[byte_search_result Tchar haystack_p (strstr haystack needle)] emp).
+     \post[search_result Tchar haystack_p (strstr haystack needle)] emp).
 
 (*  Strong but unsound before C++17, and awkward
   cpp.spec "memchr(void*, int, unsigned long)" as memchr_mut_spec with
@@ -127,7 +127,7 @@ Context `{Σ : cpp_logic, source ⊧ σ}.
               | None => (n <= hi)%Z
               end
      (*equivalently: \require hi >= n \/ (hi < n /\ exists off, memchr bytes c = Some off)*)
-     \post[byte_search_result Tuchar s_p
+     \post[search_result Tuchar s_p
        (memchr (takeZ n bytes) c)] emp).
 
   cpp.spec "memchr(const void*, int, unsigned long)" as memchr_const_spec with
@@ -141,7 +141,7 @@ Context `{Σ : cpp_logic, source ⊧ σ}.
               | None => (n <= hi)%Z
               end
      (*equivalently: \require hi >= n \/ (hi < n /\ exists off, memchr bytes c = Some off)*)
-     \post[byte_search_result Tuchar s_p
+     \post[search_result Tuchar s_p
        (memchr (takeZ n bytes) c)] emp).
 *)
 
@@ -151,14 +151,14 @@ Context `{Σ : cpp_logic, source ⊧ σ}.
      \arg{c} "__c" (Vint c)
      \arg{n} "__n" (Vint n)
      \prepost{q bytes} s_p |-> array_sliceR Tuchar 0 n (fun b : Z => ucharR q b) bytes
-     \post[byte_search_result Tuchar s_p (memchr bytes c)] emp).
+     \post[search_result Tuchar s_p (memchr bytes c)] emp).
 
   cpp.spec "memchr(const void*, int, unsigned long)" as memchr_const_simple_spec with
     (\arg{s_p} "__s" (Vptr s_p)
      \arg{c} "__c" (Vint c)
      \arg{n} "__n" (Vint n)
      \prepost{q bytes} s_p |-> array_sliceR Tuchar 0 n (fun b : Z => ucharR q b) bytes
-     \post[byte_search_result Tuchar s_p (memchr bytes c)] emp).
+     \post[search_result Tuchar s_p (memchr bytes c)] emp).
 
   cpp.spec "memcmp" with
     (\arg{s1_p} "__s1" (Vptr s1_p)

--- a/rocq-brick-libstdcpp/proof/cstring/spec.v
+++ b/rocq-brick-libstdcpp/proof/cstring/spec.v
@@ -14,13 +14,12 @@ Require Import skylabs.brick.libstdcpp.cstring.inc_cstring_cpp.
 #[local] Open Scope Z_scope.
 
 Abbreviation byte_search_result := (fun byte_ty p found =>
-Vptr (match found with
-  | Some off => (p .[ byte_ty ! off ])
-  | None => nullptr
-  end)) (only parsing).
+  Vptr (match found with
+    | Some off => (p .[ byte_ty ! off ])
+    | None => nullptr
+    end)) (only parsing).
 
-Abbreviation search_result := (fun p found =>
-  (byte_search_result Tchar p found)) (only parsing).
+Abbreviation search_result := (byte_search_result Tchar) (only parsing).
 
 Section with_cpp.
 Context `{Σ : cpp_logic, source ⊧ σ}.


### PR DESCRIPTION
Fix #118 (last commit), plus minor cleanups on the code. Best review by commit.